### PR TITLE
Point sustainabilityleadership.stanford.edu to changeleadership site.

### DIFF
--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -90,9 +90,11 @@ foreach ($sites_settings as $settings_file) {
 }
 
 // Manually point domains that don't fit naming conventions here.
-// E.g., $sites[<domain>] = "<directory>";
-// E.g., $sites[mysite.stanford.edu] = "my_site";
+// E.g., $sites['<domain>'] = '<directory>';
+// E.g., $sites['mysite.stanford.edu'] = 'my_site';
+$sites['sustainabilityleadership.stanford.edu'] = 'changeleadership';
 
+// Include local sites.
 if (file_exists(__DIR__ . '/local.sites.php')) {
   require __DIR__ . '/local.sites.php';
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Point sustainabilityleadership.stanford.edu to `changeleadership` site.
- Right now changeleadership is set as the primary domain, and sustainabilityleadership is a Vanity URL -- they want it the other way around.

# Review By (Date)
- When does this need to be reviewed by?

# Urgency
- How critical is this PR?

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
