### PR TITLE
SDSS-350: Updates for Room Reservation site in multisite stack.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,12 +53,12 @@
             "type": "package",
             "package": {
                 "name": "stanford-earth/stanford_earth_r25",
-                "version": "8.1.6",
+                "version": "8.1.7",
                 "type": "drupal-custom-module-rooms-site",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/stanford-earth/stanford_earth_r25",
-                    "reference": "8.1.6"
+                    "reference": "8.1.7"
                 }
             }
         }

--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/.htaccess
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>

--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.adminsettings.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.adminsettings.yml
@@ -1,0 +1,26 @@
+_core:
+  default_config_hash: H2llIXu_VmdjVMQdikDzj7SPnkEpGEaM2Dv1kDzp9bE
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_earth_r25_adminsettings
+label: 'R25 Admin Settings'
+description: 'R25 Room Reservation Admin Settings'
+source_type: null
+module: null
+stanford_r25_org_id: '4356'
+stanford_r25_event_type: '416'
+stanford_r25_parent_event_id: '570348'
+stanford_r25_login_msg: 'Login to reserve room'
+stanford_r25_login_uri: /user/login
+stanford_r25_notpermitted_msg:
+  value: "<p><span>You do not have permission to reserve a room using this calendar. If you believe this is in error, please contact your department administrators.</span></p>\r\n"
+  format: stanford_html
+stanford_r25_readonly_msg:
+  value: "<p><span>This calendar is read-only and can not be used to reserve the room. To reserve this room, please contact your department administrators.</span></p>\r\n"
+  format: stanford_html
+stanford_r25_booking_instructions:
+  value: "<p><span>Reservations may only be made for single occurrences of up to [max_duration]&nbsp;hours. For longer or recurring reservations,&nbsp;please&nbsp;contact your department administrator. All reservations are subject to approval by your department and the Dean's Office.</span></p>\r\n"
+  format: stanford_html
+stanford_r25_blackout_dates: {  }
+stanford_r25_reserve_msg: 'Reserve room'

--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.credentialsettings.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.credentialsettings.yml
@@ -1,0 +1,12 @@
+_core:
+  default_config_hash: eeL8a5_G3wIXAROFOujzvAGunSMyfnQVc6hPz3EHdfM
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_earth_r25_credentialsettings
+label: 'Stanford Earth R25 Credentials'
+description: 'Credential settings for access to R25 API.'
+stanford_r25_credential: /Users/ksharp/WWW/keys/r25cred
+stanford_r25_base_url: 'https://webservices.collegenet.com/r25ws/wrd/stanford/run'
+stanford_r25_room_image_directory: R25RoomPhotos
+stanford_r25_credential_contact_id: '20727'

--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.stanford_earth_r25.m310.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/stanford_earth_r25.stanford_earth_r25.m310.yml
@@ -1,0 +1,71 @@
+uuid: 9a64ba44-368e-4df2-9d68-29b57edbd321
+langcode: en
+status: true
+dependencies: {  }
+id: m310
+label: 'Mitchell 310'
+spud_name: ''
+space_id: '2473'
+email_list: ksharp@stanford.edu
+updated: 'Mon, 10/23/2023 - 15:36'
+displaytype: '3'
+caltype: '2'
+max_hours: '2'
+default_view: '2'
+description_as_title: 0
+permalink: 0
+honor_blackouts: 0
+override_blackout_instructions:
+  value: ''
+  format: stanford_html
+approver_secgroup_name: ''
+approver_secgroup_id: ''
+email_cancellations: 0
+multi_day: 0
+postprocess_booking: 0
+override_booking_instructions:
+  value: ''
+  format: stanford_html
+event_attributes: ''
+event_attributes_fields: {  }
+contact_attribute: ''
+contact_attribute_field: {  }
+auto_billing_code: ''
+override_view_roles:
+  administrator: 0
+  anonymous: 0
+  authenticated: 0
+  stanford_faculty: 0
+  stanford_staff: 0
+  stanford_student: 0
+  contributor: 0
+  site_manager: 0
+  site_editor: 0
+  site_builder: 0
+  site_developer: 0
+  layout_builder_user: 0
+  decoupled_site_users: 0
+override_book_roles:
+  administrator: 0
+  anonymous: 0
+  authenticated: 0
+  stanford_faculty: 0
+  stanford_staff: 0
+  stanford_student: 0
+  contributor: 0
+  site_manager: 0
+  site_editor: 0
+  site_builder: 0
+  site_developer: 0
+  layout_builder_user: 0
+  decoupled_site_users: 0
+nopopup_reservation_form: 0
+location_info:
+  capacity: '10'
+  comments: '<p>This room may <strong>not</strong> be booked for seminars and conferences.</p>'
+  layout_name: 'Boardroom [BR]'
+  layout_instruction: null
+  layout_features: 'Internet, Wired, Monitor, LED'
+  layout_categories: 'Departmentally Scheduled, EMCS, SDSS Scheduled'
+  photo_id: '1383'
+locationtype: '1'

--- a/docroot/profiles/sdss/sdss_profile/config/sync/config_ignore.settings.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/config_ignore.settings.yml
@@ -17,4 +17,7 @@ ignored_config_entities:
   - 'migrate_plus.migration.earth_news_importer*'
   - 'core.extension:module.earth_news_importer'
   - 'samlauth.authentication:map_users_roles'
+  - 'stanford_earth_r25.adminsettings'
+  - 'stanford_earth_r25.credentialsettings'
+  - 'stanford_earth_r25.stanford_earth_r25.*'
 enable_export_filtering: false

--- a/docroot/profiles/sdss/sdss_profile/config/sync/config_split.config_split.room_reservations.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/config_split.config_split.room_reservations.yml
@@ -1,0 +1,16 @@
+uuid: e570d8ce-9b41-4165-b9c5-d05f6f900747
+langcode: en
+status: false
+dependencies: {  }
+id: room_reservations
+label: 'Room Reservations'
+description: ''
+weight: 0
+stackable: false
+storage: folder
+folder: profiles/sdss/sdss_profile/config/sdssrooms
+module:
+  stanford_earth_r25: 0
+theme: {  }
+complete_list: {  }
+partial_list: {  }

--- a/docroot/sites/sdssrooms/settings.php
+++ b/docroot/sites/sdssrooms/settings.php
@@ -648,6 +648,11 @@ if ($settings['hash_salt']) {
 # $config['system.performance']['fast_404']['html'] = '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 
 /**
+ * Config Split Setting for rooms
+ */
+$config["config_split.config_split.room_reservations"]["status"] = TRUE;
+
+/**
  * Load services definition file.
  */
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';

--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -42,6 +42,9 @@ if (EnvironmentDetector::isAhEnv()) {
       'system.action.user_add_role_action.*',
       'system.action.user_remove_role_action.*',
       'samlauth.authentication',
+      'stanford_earth_r25.adminsettings',
+      'stanford_earth_r25.credentialsettings',
+      'stanford_earth_r25.stanford_earth_r25.*',
     ];
     $settings['config_readonly_content_link_providers'] = [
       'menu_link_content',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
1. Updates composer.json to use latest stanford_earth_r25 module (v1.7) with fixes for SDSS stack and Drupal 10.x
2. Adds room reservation config to config_readonly whitelist
3. Adds room reservation config to config_ignore settings
4. Creates a config_split (hopefully) active only for the sdssrooms site that keeps the module enabled.

**NB**:  If there is another/better way to make sure the stanford_earth_r25 module remains enabled after code/config updates, I'd be happy to simplify. I also don't know if I need to have room configs saved in an sdssrooms sync directory or not, or if I still need config_ignore settings while using config_split. I can do some more testing, but I wanted to make sure this new version of the rooms module gets into the next build.

# Review By (Date)d
- Before 3.x push to production.

# Review Tasks

## Setup tasks and/or behavior to test

1. drush cim to sdssrooms site to make sure - room reservation module remains enabled, room configuration can be done from ui, and existing configurations are untouched.
2. drush cim to another site on the stack to make sure room reservation module is *not* enabled and no other problems come up with the config import


