### PR TITLE
SDSS-846: fix the misspelled tabindex

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_profile_helper/templates/news-vertical-teaser/pattern-news-vertical-teaser.html.twig
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_profile_helper/templates/news-vertical-teaser/pattern-news-vertical-teaser.html.twig
@@ -41,7 +41,7 @@
 <article{{ attributes.addClass(classes) }}>
   {%- if news_url is not empty and news_vertical_teaser_image|render|striptags("<drupal-render-placeholder> <img>")|trim is not empty -%}
     <div class="su-figure__wrapper">
-      <a {{ news_url_attributes.addClass('su-news-vertical-teaser__link') }} href="{{ news_url }}" tab-index="-1" aria-hidden="true">
+      <a {{ news_url_attributes.addClass('su-news-vertical-teaser__link') }} href="{{ news_url }}" tabindex="-1" aria-hidden="true">
         <figure class="su-media su-media--image su-card__media">
           <div class="su-media__wrapper">
             {{- news_vertical_teaser_image -}}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the `tab-index` to the correct `tabindex`

# Review By (Date)
- soon

# Criticality
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to a page.
3. Create a bunch of teasers.
4. Verify there is no more `tab-index` on the news vertical teaser. It is replaced with `tabindex`

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- SDSS-846](https://stanfordits.atlassian.net/browse/SDSS-846)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
