### PR TITLE
SDSS-1238: Add 'view r25 room calendars' user perm to sdssroom config

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/config_split.patch.user.role.authenticated.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/config_split.patch.user.role.authenticated.yml
@@ -4,4 +4,5 @@ adding:
       - stanford_earth_r25
   permissions:
     - 'book r25 rooms'
+    - 'view r25 room calendars'
 removing: {  }

--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/user.role.authenticated.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/user.role.authenticated.yml
@@ -41,6 +41,7 @@ permissions:
   - 'view own su_site_url'
   - 'view policy log'
   - 'view printer friendly versions'
+  - 'view r25 room calendars'
   - 'view sdss entity'
   - 'view su_metatags'
   - 'view su_policy_auto_prefix'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Config split for sdssrooms does not set the above named permission for authenticated users.

# Review By (Date)
- Before next production release or hotfix.

# Criticality
- Affects only one site https://sdssrooms.stanford.edu but without this fix the ability
to view calendars for authenticated users will break after a code update until manually set

# Review Tasks

## Setup tasks and/or behavior to test

1. Install the sdssrooms site.
2. Check permissions page that 'view r25 room calendars' is set for authenticated users

