### PR TITLE
SDSS-359: number of people on initial load of view page

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
@@ -396,7 +396,7 @@ display:
         type: infinite_scroll
         options:
           offset: 0
-          items_per_page: 39
+          items_per_page: 36
           total_pages: null
           id: 0
           tags:
@@ -413,6 +413,7 @@ display:
           views_infinite_scroll:
             button_text: 'Load More People'
             automatically_load_content: false
+            initially_load_all_pages: false
       exposed_form:
         type: basic
         options:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- changed the number of people on initial load from 39 to 36 to be divisible by 4.

# Review By (Date)
- Soon

# Criticality
- normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Import the config
3. Navigate to to the content page and create 50+ people
4. Go to the `/people` page and verify there are only 36 people listed and no widows.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- SDSS-359](https://stanfordits.atlassian.net/browse/SDSS-359)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
