### PR TITLE
SDSS-1305: Remove width options from SDSS layout paragraphs

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/layouts/one_column/one-column.css
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/layouts/one_column/one-column.css
@@ -26,8 +26,4 @@
     margin: 0 auto;
   }
 
-  .sdss-layout-paragraphs-one-column--offset-100 .paragraph.paragraph--type--stanford-wysiwyg {
-    max-width: 100%;
-  }
-
 }

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/layouts/two_column/two-column.css
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/layouts/two_column/two-column.css
@@ -73,23 +73,6 @@
   min-width: 0;
 }
 
-.layout--layout-paragraphs-two-column.sdss-layout-paragraphs-two-column--33-67 {
-  grid-template-columns: 1fr 2fr;
-}
-
-.layout--layout-paragraphs-two-column.sdss-layout-paragraphs-two-column--67-33 {
-  grid-template-columns: 2fr 1fr;
-}
-
-.layout--layout-paragraphs-two-column.sdss-layout-paragraphs-two-column--offset-50-50 {
-  margin: 0;
-  max-width: 1200px;
-}
-
-.layout-paragraphs-sdss-two-column.layout-paragraphs-sdss-two-column--offset-50-50 {
-  margin: 0;
-}
-
 /* Override Stanford Basic theme */
 @media screen and (min-width: 1700px) {
   .su-page-components .layout--layout-paragraphs-three-column,

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/OneColumn.php
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/OneColumn.php
@@ -9,10 +9,4 @@ use Drupal\sdss_layout_paragraphs\Plugin\Layout\SdssLayoutParagraphBase;
  */
 class OneColumn extends SdssLayoutParagraphBase {
 
-  protected function getWidthOptions() {
-    return [
-      '100' => '100%',
-      'offset-100' => 'Offset: 100%',
-    ];
-  }
 }

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/OneFourOne.php
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/OneFourOne.php
@@ -9,9 +9,4 @@ use Drupal\sdss_layout_paragraphs\Plugin\Layout\SdssLayoutParagraphBase;
  */
 class OneFourOne extends SdssLayoutParagraphBase {
 
-  protected function getWidthOptions() {
-    return [
-      '25-25-25-25' => '25%',
-    ];
-  }
 }

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/ThreeColumn.php
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/ThreeColumn.php
@@ -9,10 +9,4 @@ use Drupal\sdss_layout_paragraphs\Plugin\Layout\SdssLayoutParagraphBase;
  */
 class ThreeColumn extends SdssLayoutParagraphBase {
 
-  protected function getWidthOptions() {
-    return [
-      '100' => '100%',
-      // 'offset-100' => 'Offset: 100%',
-    ];
-  }
 }

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/TwoColumn.php
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Layouts/TwoColumn.php
@@ -9,16 +9,4 @@ use Drupal\sdss_layout_paragraphs\Plugin\Layout\SdssLayoutParagraphBase;
  */
 class TwoColumn extends SdssLayoutParagraphBase {
 
-  /**
-   * {@inheritDoc}
-   */
-  protected function getWidthOptions() {
-    return [
-      '50-50' => '50% - 50%',
-      // 'offset-50-50' => 'Offset: 50% - 50%',
-      // '33-67' => '33% - 67%',
-      // '67-33' => '67% - 33%',
-    ];
-  }
-
 }

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Plugin/Layout/SdssLayoutParagraphBase.php
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_layout_paragraphs/src/Plugin/Layout/SdssLayoutParagraphBase.php
@@ -4,7 +4,7 @@ namespace Drupal\sdss_layout_paragraphs\Plugin\Layout;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
-use Drupal\layout_builder\Plugin\Layout\MultiWidthLayoutBase;
+use Drupal\Core\Layout\LayoutDefault;
 
 
 /**
@@ -13,7 +13,7 @@ use Drupal\layout_builder\Plugin\Layout\MultiWidthLayoutBase;
  * @internal
  *   Plugin classes are internal.
  */
-abstract class SdssLayoutParagraphBase extends MultiWidthLayoutBase implements PluginFormInterface {
+abstract class SdssLayoutParagraphBase extends LayoutDefault implements PluginFormInterface {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed width options from SDSS layout paragraphs.
- Also resolves bug in SDSS-835

# Review By (Date)
ASAP

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Create a new Basic Page
3. Add a new section / layout paragraph
4. Confirm the width options are gone
5. Add a 2 column layout paragraph
6. Add a paragraph into the right column
7. Switch the 2 column layout to a 1 column layout
8. Confirm the UI/form asks what region you want to move the existing paragraphs into (Move orphaned items)

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/SDSS-1298
https://stanfordits.atlassian.net/browse/SDSS-835
