### PR TITLE
SDSS-1270: Deprecate and fully remove earth_news_importer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,19 +39,6 @@
         {
             "type": "package",
             "package": {
-                "name": "su-sws/earth_news_importer",
-                "version": "1.x-dev",
-                "type": "drupal-custom-module",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/SU-SWS/earth_news_importer.git",
-                    "reference": "1.x"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
                 "name": "stanford-earth/stanford_earth_r25",
                 "version": "8.1.12",
                 "type": "drupal-custom-module-rooms-site",
@@ -195,7 +182,6 @@
         "su-sws/blt-sws": "dev-main",
         "su-sws/ckeditor5_plugins": "^1.0",
         "su-sws/drupal-patches": "^10.0",
-        "su-sws/earth_news_importer": "1.x-dev",
         "su-sws/react_paragraphs": "^8.2",
         "su-sws/stanford_actions": "^8.2",
         "su-sws/stanford_fields": "^8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edcfa3a5b0fea92067d7db766e5b3a39",
+    "content-hash": "1ade949b02bd9d29ecce637cc93516f3",
     "packages": [
         {
             "name": "acquia/blt",
@@ -16557,16 +16557,6 @@
             "time": "2024-05-28T17:57:40+00:00"
         },
         {
-            "name": "su-sws/earth_news_importer",
-            "version": "1.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/SU-SWS/earth_news_importer.git",
-                "reference": "1.x"
-            },
-            "type": "drupal-custom-module"
-        },
-        {
             "name": "su-sws/react_paragraphs",
             "version": "8.2.17",
             "source": {
@@ -26782,8 +26772,7 @@
         "drupal/views_block_filter_block": 10,
         "drupal/webp": 10,
         "onlyextart/colorbox": 20,
-        "su-sws/blt-sws": 20,
-        "su-sws/earth_news_importer": 20
+        "su-sws/blt-sws": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/docroot/profiles/sdss/sdss_profile/config/sync/config_ignore.settings.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/config_ignore.settings.yml
@@ -3,12 +3,9 @@ _core:
 mode: simple
 ignored_config_entities:
   - 'block.block.*'
-  - 'core.extension:module.earth_news_importer'
   - 'core.extension:theme'
   - 'google_tag.container.*'
   - 'metatag.metatag_defaults.*'
-  - 'migrate_plus.migration.earth_news_importer*'
-  - migrate_plus.migration_group.earth_news_importer
   - 'next.next_entity_type_config.*'
   - 'next.next_site.*'
   - 'samlauth.authentication:map_users_roles'

--- a/tests/phpunit/example.phpunit.xml
+++ b/tests/phpunit/example.phpunit.xml
@@ -21,12 +21,9 @@
       <directory>../profiles/custom/*/modules/*/tests</directory>
       <directory>../profiles/sdss/*/tests</directory>
       <!-- <directory>../profiles/sdss/*/modules/*/tests</directory> -->
-      <!-- Exclude custom sdss_profile modules for now. Tests need to be written
-       ASAP. -->
+      <!-- Exclude custom sdss_profile modules for now. Tests need to be
+      written. -->
       <directory>../profiles/sdss/*/modules</directory>
-      <!-- Exclude the earth_news_importer custom module. This module will be
-       removed. -->
-      <directory>../modules/custom/earth_news_importer</directory>
     </exclude>
   </coverage>
   <!-- set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-1270](https://stanfordits.atlassian.net/browse/SDSS-1270): DEV | Deprecate and remove earth_news_importer


[SDSS-1270]: https://stanfordits.atlassian.net/browse/SDSS-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ