### PR TITLE
SDSS-1341: Enhanced Contextual filters on News 

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_news.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_news.yml
@@ -843,7 +843,7 @@ display:
           field: term_node_taxonomy_name_depth
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: 'Any Term'
           default_action: ignore
           exception:
             value: all
@@ -870,7 +870,10 @@ display:
           validate_options: {  }
           depth: '3'
           vocabularies:
+            sdss_focal_areas: sdss_focal_areas
+            sdss_organization: sdss_organization
             stanford_news_topics: stanford_news_topics
+            su_shared_tags: su_shared_tags
           break_phrase: 1
           use_taxonomy_term_path: false
           entity_type: node
@@ -2458,7 +2461,7 @@ display:
           field: term_node_taxonomy_name_depth
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: 'Any Term'
           default_action: ignore
           exception:
             value: all
@@ -2485,7 +2488,10 @@ display:
           validate_options: {  }
           depth: '3'
           vocabularies:
+            sdss_focal_areas: sdss_focal_areas
+            sdss_organization: sdss_organization
             stanford_news_topics: stanford_news_topics
+            su_shared_tags: su_shared_tags
           break_phrase: 1
           use_taxonomy_term_path: false
           entity_type: node


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- Woods would like to be able to filter news by Focal Area, Shared Tags, and Organization taxonomies for the List Paragraph
- This is focused on the Default List and Card Grid displays

# Review By (Date)
- August 2024

# Criticality
- High. It is blocking some institute sites.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Make some news
3. Tag it using one of the vocabs mentioned above
4. Verify the filtering works by creating a list paragraph

## Front End Validation
No front-end impact to this PR

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
SDSS-1341

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
