### PR TITLE
SDSS-460: Allow editing of URL alias for News, Events, Peopple

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_event.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_event.default.yml
@@ -41,6 +41,7 @@ dependencies:
     - link
     - media_library
     - paragraphs
+    - path
     - readonly_field_widget
     - scheduler
     - smart_date
@@ -125,7 +126,7 @@ third_party_settings:
       label: Taxonomy
       region: content
       parent_name: ''
-      weight: 10
+      weight: 9
       format_type: details
       format_settings:
         classes: ''
@@ -149,20 +150,26 @@ content:
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
+  path:
+    type: path
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   stanford_intranet__access:
     type: entity_access
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -192,7 +199,9 @@ content:
     weight: 4
     region: content
     settings:
+      view_mode: default
       preview_view_mode: default
+      form_display_mode: default
       nesting_depth: 0
       require_layouts: 1
       empty_message: ''
@@ -394,7 +403,7 @@ content:
         add_another: ''
   su_sdss_related_content:
     type: entity_reference_autocomplete
-    weight: 32
+    weight: 12
     region: content
     settings:
       match_operator: CONTAINS
@@ -426,7 +435,6 @@ content:
 hidden:
   created: true
   layout_builder__layout: true
-  path: true
   promote: true
   sticky: true
   su_metatags: true

--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -38,6 +38,7 @@ dependencies:
     - link
     - media_library
     - metatag
+    - path
     - scheduler
     - stanford_intranet
     - text
@@ -99,7 +100,7 @@ third_party_settings:
       label: Taxonomy
       region: content
       parent_name: ''
-      weight: 6
+      weight: 5
       format_type: details
       format_settings:
         classes: ''
@@ -129,33 +130,39 @@ targetEntityType: node
 bundle: stanford_news
 mode: default
 content:
+  path:
+    type: path
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   stanford_intranet__access:
     type: entity_access
-    weight: 8
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   su_metatags:
     type: metatag_firehose
-    weight: 9
+    weight: 8
     region: content
     settings:
       sidebar: true
@@ -189,7 +196,9 @@ content:
     weight: 4
     region: content
     settings:
+      view_mode: default
       preview_view_mode: default
+      form_display_mode: default
       nesting_depth: 0
       require_layouts: 1
       empty_message: ''
@@ -232,7 +241,7 @@ content:
     third_party_settings: {  }
   su_sdss_media_contacts:
     type: inline_entity_form_complex
-    weight: 12
+    weight: 11
     region: content
     settings:
       form_mode: default
@@ -247,14 +256,6 @@ content:
       collapsed: false
       revision: false
       removed_reference: keep
-      auto_open: true
-      allow_edit: true
-      hide_fieldset: false
-      hide_title: false
-      config_labels_button: _none
-      labels: {  }
-      add_existing_widget: autocomplete
-      auto_open_edit_form: false
     third_party_settings:
       change_labels:
         add_another: 'Add another Media Contact'
@@ -263,7 +264,7 @@ content:
         force_single_cardinality: 0
   su_sdss_media_mention:
     type: boolean_checkbox
-    weight: 13
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -368,7 +369,7 @@ content:
     third_party_settings: {  }
   syndication:
     type: boolean_checkbox
-    weight: 54
+    weight: 13
     region: content
     settings:
       display_label: true
@@ -385,7 +386,6 @@ hidden:
   created: true
   layout_builder__layout: true
   layout_selection: true
-  path: true
   promote: true
   sticky: true
   su_news_dek: true

--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -52,6 +52,7 @@ dependencies:
     - media_library
     - menu_link
     - metatag
+    - path
     - scheduler
     - stanford_intranet
     - text
@@ -160,18 +161,24 @@ content:
         hide_guidelines: '0'
   field_menulink:
     type: menu_link_default
-    weight: 53
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 52
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 50
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -190,7 +197,7 @@ content:
     third_party_settings: {  }
   su_metatags:
     type: metatag_firehose
-    weight: 32
+    weight: 9
     region: content
     settings:
       sidebar: true
@@ -209,7 +216,9 @@ content:
     weight: 7
     region: content
     settings:
+      view_mode: default
       preview_view_mode: default
+      form_display_mode: default
       nesting_depth: 0
       require_layouts: 1
       empty_message: ''
@@ -374,7 +383,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_alt_bio:
     type: text_textarea
-    weight: 36
+    weight: 14
     region: content
     settings:
       rows: 5
@@ -382,7 +391,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_alt_title:
     type: text_textarea
-    weight: 35
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -403,7 +412,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_organization:
     type: cshs
-    weight: 32
+    weight: 10
     region: content
     settings:
       save_lineage: false
@@ -416,7 +425,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_research_area:
     type: cshs
-    weight: 33
+    weight: 11
     region: content
     settings:
       save_lineage: false
@@ -429,7 +438,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_research_state:
     type: text_textarea
-    weight: 34
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -437,7 +446,7 @@ content:
     third_party_settings: {  }
   su_sdss_related_content:
     type: entity_reference_autocomplete
-    weight: 53
+    weight: 18
     region: content
     settings:
       match_operator: CONTAINS
@@ -447,7 +456,7 @@ content:
     third_party_settings: {  }
   su_shared_tags:
     type: cshs
-    weight: 31
+    weight: 8
     region: content
     settings:
       save_lineage: false
@@ -469,7 +478,6 @@ content:
 hidden:
   created: true
   layout_builder__layout: true
-  path: true
   promote: true
   sticky: true
   su_person_academic_appt: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Woods, Precourt, and sometimes the School site need to be able to edit their URL aliases

# Review By (Date)
- August

# Criticality
- HIGH

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Try to edit an event, news, or person
3. Try to edit the alias
4. Profit!

## Front End Validation
No front-end impact to this PR


## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- SDSS Stack

# Associated Issues and/or People
- SDSS-460

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
