### PR TITLE
SDSS-1358: Allow all editors to use Related Content field

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.node.su_sdss_related_content.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.node.su_sdss_related_content.yml
@@ -3,11 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - field_permissions
     - node
-third_party_settings:
-  field_permissions:
-    permission_type: custom
 id: node.su_sdss_related_content
 field_name: su_sdss_related_content
 entity_type: node

--- a/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -393,18 +393,6 @@ class BasicPageCest {
     $I->canSee('Last Updated: ' . $date_string);
   }
 
-  public function testRelatedContent(AcceptanceTester $I){
-    // A quick test to make sure it's only visible to administrators.
-    $I->logInWithRole('contributor');
-    $I->amOnPage('/node/add/stanford_page');
-    $I->cantSee('Related Content');
-    $I->amOnPage('/user/logout');
-    $I->runDrush('cr');
-    $I->logInWithRole('administrator');
-    $I->amOnPage('/node/add/stanford_page');
-    $I->canSee('Related Content');
-  }
-
   protected static function getTimezone() {
     return \Drupal::config('system.date')
       ->get('timezone.default') ?: @date_default_timezone_get();

--- a/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -246,16 +246,4 @@ class PublicationsCest {
     $I->canSee('Publisher');
   }
 
-  public function testRelatedContent(AcceptanceTester $I){
-    // A quick test to make sure it's only visible to administrators.
-    $I->logInWithRole('contributor');
-    $I->amOnPage('/node/add/stanford_publication');
-    $I->cantSee('Related Content');
-    $I->amOnPage('/user/logout');
-    $I->runDrush('cr');
-    $I->logInWithRole('administrator');
-    $I->amOnPage('/node/add/stanford_publication');
-    $I->canSee('Related Content');
-  }
-
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjust permissions for the Related Content field so that it has the same permissions as the content types associated with it

# Review By (Date)
- Not required for release of Explore More, so could wait until next release

# Criticality
Medium

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Change yourself to a site manager or site editor
3. Try to use the field

## Front End Validation
No Front-end impact

## Backend / Functional Validation
### Code
Not much new here either!

### Code security
All good!

## General
- [ NOPE] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [YES  ] Is the approach to the problem appropriate?

# Affected Projects or Products
- News

# Associated Issues and/or People
- SDSS-1299

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
