### PR TITLE
SDSS-1376: Remove "/r25/*/calendar" from block.stanford_basic.pagetitle

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sdssrooms/block.block.stanford_basic_pagetitle.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sdssrooms/block.block.stanford_basic_pagetitle.yml
@@ -23,7 +23,7 @@ visibility:
     id: request_path
     negate: true
     context_mapping: {  }
-    pages: "/node/*\r\n/news*\r\n/people*\r\n/events*\r\n/event-series*\r\n/publications*\r\n/courses*\r\n/r25/*/calendar"
+    pages: "/node/*\r\n/news*\r\n/people*\r\n/events*\r\n/event-series*\r\n/publications*\r\n/courses*"
   response_code:
     id: response_code
     negate: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- block.stanford_basic.pagetitle was hiding the page title for calendar pages. we now want to show the page titles.

# Review By (Date)
- ASAP. Before next release if possible.

# Criticality
- Not critical, but I have to manually update the block after every production release.

