### PR TITLE
SDSS-1376: Update stanford_earth_r25 module to 8.1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
             "type": "package",
             "package": {
                 "name": "stanford-earth/stanford_earth_r25",
-                "version": "8.1.12",
+                "version": "8.1.13",
                 "type": "drupal-custom-module-rooms-site",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/stanford-earth/stanford_earth_r25",
-                    "reference": "8.1.12"
+                    "reference": "8.1.13"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b636c4d19eab9c5d6f4bb0339042ca7",
+    "content-hash": "26b6c90d6c309c1e9697627078352fbf",
     "packages": [
         {
             "name": "acquia/blt",
@@ -16436,11 +16436,11 @@
         },
         {
             "name": "stanford-earth/stanford_earth_r25",
-            "version": "8.1.12",
+            "version": "8.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stanford-earth/stanford_earth_r25",
-                "reference": "8.1.12"
+                "reference": "8.1.13"
             },
             "type": "drupal-custom-module-rooms-site"
         },


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates stanford_earth_r25 module from 8.1.12 to 8.1.13

# Review By (Date)
- Next feasible code update.

# Criticality
- Not critical, but adds feature for Hartley reservations needed by SDSS Dean's Office staff

# Review Tasks
- Let Kassie Sharp know when build is available on https://sdssrooms-test.stanford.edu and Kassie will test
