### PR TITLE
SDSS-000: Add patch to remove defunct placeimg URL from unit test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -376,6 +376,9 @@
             },
             "drupal/webp": {
                 "https://www.drupal.org/project/webp/issues/3281606": "patches/contrib/webp-mr-33.patch"
+            },
+            "su-sws/stanford_migrate": {
+                "Remove placeimage URL from unit test": "patches/stanford/stanford_migrate-placeimg-test-fix.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18d62cbce60cace3196206f6a35914aa",
+    "content-hash": "3c3dd1670586f13098075d98f8403b4e",
     "packages": [
         {
             "name": "acquia/blt",

--- a/patches/stanford/stanford_migrate-placeimg-test-fix.patch
+++ b/patches/stanford/stanford_migrate-placeimg-test-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/src/Unit/Plugin/migrate/process/StanfordFileImportTest.php b/tests/src/Unit/Plugin/migrate/process/StanfordFileImportTest.php
+index c13db27..a116d92 100644
+--- a/tests/src/Unit/Plugin/migrate/process/StanfordFileImportTest.php
++++ b/tests/src/Unit/Plugin/migrate/process/StanfordFileImportTest.php
+@@ -55,8 +55,6 @@ class StanfordFileImportTest extends UnitTestCase {
+     $migrate_executable = $this->createMock(MigrateExecutable::class);
+     $row = $this->createMock(Row::class);
+     $this->assertNull($plugin->transform('https://identity.stanford.edu/wp-content/uploads/sites/3/2020/07/block-s-right.png', $migrate_executable, $row, 'field_stuff'));
+-    $this->assertNull($plugin->transform('https://placeimg.com/640/480/any', $migrate_executable, $row, 'field_stuff'));
+-
+ 
+     $configuration = ['max_size' => '10MB'];
+     $definition = [];

--- a/tests/phpunit/example.phpunit.xml
+++ b/tests/phpunit/example.phpunit.xml
@@ -71,8 +71,6 @@
       <directory>../profiles/sdss</directory>
       <!-- Exclude the stanford_syndication custom module tests for now. -->
       <exclude>../modules/custom/stanford_syndication</exclude>
-      <!-- Exclude the stanford_migrate module until the placeimg URL is fixed in test -->
-      <exclude>../modules/custom/stanford_migrate</exclude>
     </testsuite>
   </testsuites>
   <listeners>

--- a/tests/phpunit/example.phpunit.xml
+++ b/tests/phpunit/example.phpunit.xml
@@ -71,6 +71,8 @@
       <directory>../profiles/sdss</directory>
       <!-- Exclude the stanford_syndication custom module tests for now. -->
       <exclude>../modules/custom/stanford_syndication</exclude>
+      <!-- Exclude the stanford_migrate module until the placeimg URL is fixed in test -->
+      <exclude>../modules/custom/stanford_migrate</exclude>
     </testsuite>
   </testsuites>
   <listeners>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a patch to fix PHP Unit test failures. Remove [the defunct placeimg URL test is fixed](https://github.com/SU-SWS/stanford_migrate/blob/d695c0278128b811fecfab05283c04387318237a/tests/src/Unit/Plugin/migrate/process/StanfordFileImportTest.php#L58)

