### PR TITLE
SDSS-1378: FIX | Set default value for explore more picker

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -1028,7 +1028,7 @@ function sdss_profile_update_10012() {
  * Set default value for the su_sdss_explore_more_picker field on all existing
  * nodes.
  */
-function sdss_profile_update_10013() {
+function sdss_profile_update_10013(&$sandbox) {
   $node_storage = \Drupal::entityTypeManager()
     ->getStorage('node');
   if (!isset($sandbox['count'])) {

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -1106,3 +1106,43 @@ function sdss_profile_update_10015(&$sandbox) {
 
   $sandbox['#finished'] = empty($sandbox['nids']) ? 1 : ($sandbox['count'] - count($sandbox['nids'])) / $sandbox['count'];
 }
+
+/**
+ * Set default value for the su_sdss_explore_more_picker field on all existing
+ * nodes without a set value.
+ */
+function sdss_profile_update_10016(&$sandbox) {
+  $node_storage = \Drupal::entityTypeManager()
+    ->getStorage('node');
+  if (!isset($sandbox['count'])) {
+    $nids = $node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'stanford_news')
+      ->sort('created', 'DESC')
+      ->execute();
+    $sandbox['nids'] = $nids;
+    $sandbox['count'] = count($sandbox['nids']);
+  }
+
+  $node_ids = array_splice($sandbox['nids'], 0, 100);
+  /** @var \Drupal\node\NodeInterface[] $nodes */
+  $nodes = $node_storage->loadMultiple($node_ids);
+  $default_value = [
+    0 => [
+      'target_id' => 'explore_more_news',
+      'display_id' => 'explore_more_random',
+      'arguments' => '',
+      'items_to_display' => '',
+    ]
+  ];
+  foreach ($nodes as $node) {
+    if (!$node->hasField('su_sdss_explore_more_picker')) {
+      continue;
+    }
+    if ($node->get('su_sdss_explore_more_picker')->isEmpty()) {
+      $node->set('su_sdss_explore_more_picker', $default_value)->save();
+    }
+  }
+
+  $sandbox['#finished'] = empty($sandbox['nids']) ? 1 : ($sandbox['count'] - count($sandbox['nids'])) / $sandbox['count'];
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the default value for explore more picker field where it's not set
- This is a fix for a previous update which only updated the first batch of nodes because it was missing the `&$sandbox` parameter in the hook to keep batching.

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/SDSS-1378

