### PR TITLE
SDSS-1431: Removed edit button from Stanford Person view.

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
@@ -1152,59 +1152,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        edit_node:
-          id: edit_node
-          table: node
-          field: edit_node
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: entity_link_edit
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: div
-          element_class: su-people-edit-article
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          text: 'edit this item'
-          output_url_as_text: false
-          absolute: false
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth

--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_person.yml
@@ -888,59 +888,6 @@ display:
           separator: ', '
           field_api_classes: 0
           plugin_id: field
-        edit_node:
-          id: edit_node
-          table: node
-          field: edit_node
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: div
-          element_class: su-people-edit-article
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          text: 'edit this item'
-          output_url_as_text: false
-          absolute: false
-          entity_type: node
-          plugin_id: entity_link_edit
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-1431](https://stanfordits.atlassian.net/browse/SDSS-1431) | Edit buttons are shown publicly on people nodes
Removes the 'edit this item' button from the Stanford Person view to prevent it from displaying for unauthorized users.

# Review By (Date)

# Criticality

# Review Tasks
Verify that the edit content links are not present in the Fields section on the People view here, /admin/structure/views/view/stanford_person


## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to...
3. Verify...

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)


[SDSS-1431]: https://stanfordits.atlassian.net/browse/SDSS-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ