### PR TITLE
SDSS-1391: Add 'www' to Stanford University brand bar link

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/modules/stanford_profile_helper/modules/jumpstart_ui/dist/templates/decanter/components/brand-bar/brand-bar.twig
+++ b/docroot/profiles/sdss/sdss_profile/modules/stanford_profile_helper/modules/jumpstart_ui/dist/templates/decanter/components/brand-bar/brand-bar.twig
@@ -21,5 +21,5 @@
 {%- endif %}
 
 <div class="su-brand-bar {{ modifier_class }}">
-  <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://stanford.edu">Stanford University{{ external_link_text }}</a></div>
+  <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://www.stanford.edu">Stanford University{{ external_link_text }}</a></div>
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Updated the hardcoded URL in the brand-bar template from https://stanford.edu to https://www.stanford.edu.

# Review By (Date)


# Criticality
- How critical is this PR on a 1-10 scale? See [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
1

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild cache
3. Verify that the brand-bar's Stanford University link is https://www.stanford.edu.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/SDSS-1391

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
