### PR TITLE
SDSS-1333: Move SDSS News Sharing Settings to Configuration->Importers

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_news_sharing/sdss_news_sharing.links.menu.yml
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_news_sharing/sdss_news_sharing.links.menu.yml
@@ -2,4 +2,4 @@ sdss_news_sharing.news_sharing_settings_form:
   title: 'SDSS News Sharing Settings'
   route_name: sdss_news_sharing.news_sharing_settings_form
   description: 'Modify the SDSS New Sharing Settings'
-  parent: system.admin_config_services
+  parent: stanford_migrate.list

--- a/docroot/profiles/sdss/sdss_profile/modules/sdss_news_sharing/sdss_news_sharing.routing.yml
+++ b/docroot/profiles/sdss/sdss_profile/modules/sdss_news_sharing/sdss_news_sharing.routing.yml
@@ -1,5 +1,5 @@
 sdss_news_sharing.news_sharing_settings_form:
-  path: '/admin/config/services/sdss-news-sharing'
+  path: '/admin/config/importers/sdss-news-sharing'
   defaults:
     _form: '\Drupal\sdss_news_sharing\Form\NewsSharingSettingsForm'
     _title: 'SDSS News Sharing Settings'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Moved the SDSS News Sharing Settings to be a menu link in Importers and changed the route to match.

# Review By (Date)

# Criticality

# Review Tasks
1. Pull the changes and rebuild cache.
2. Verify that the 'SDSS News Sharing Settings' menu link is no longer listed in the admin toolbar under Configuration->Web Services, and is available under Configuration->Importers.
3. Navigate to /admin/config/importers/sdss-news-sharing and verify that the news sharing form is present.

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Associated Issues and/or People
https://stanfordits.atlassian.net/browse/SDSS-1333
