### PR TITLE
SDSS-1477: Manually point neza.stanford.edu to the nza site

### DIFF
--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -97,9 +97,10 @@ $sites['earthsystems.stanford.edu'] = 'esys';
 $sites['eep.stanford.edu'] = 'gep';
 $sites['energypostdoc.stanford.edu'] = 'sepf';
 $sites['epsci.stanford.edu'] = 'gs';
+$sites['esos.stanford.edu'] = 'environmentalsocialsci';
+$sites['neza.stanford.edu'] = 'nza';
 $sites['sustainabilityleadership.stanford.edu'] = 'changeleadership';
 $sites['understand-energy.stanford.edu'] = 'understandenergy';
-$sites['esos.stanford.edu'] = 'environmentalsocialsci';
 
 // Manually point dev/test domains here.
 $sites['understand-energy-dev.stanford.edu'] = 'understandenergy';


### PR DESCRIPTION
# Summary
Manually point neza.stanford.edu to the `nza` site.
[SDSS-1477](https://stanfordits.atlassian.net/browse/SDSS-1477): LAUNCH | Launch neza.stanford.edu 3/11/25
