### PR TITLE
HSD8-000: Change code deploy hook for enabling field_validation_legacy module

### DIFF
--- a/blt/src/Blt/Plugin/Commands/GryphonHooksCommands.php
+++ b/blt/src/Blt/Plugin/Commands/GryphonHooksCommands.php
@@ -14,7 +14,7 @@ use Robo\Contract\VerbosityThresholdInterface;
 class GryphonHooksCommands extends BltTasks {
 
   /**
-   * @hook pre-command sws:pre-code-deploy
+   * @hook pre-command sws:post-code-deploy
    */
   public function preSwsCodeDeploy()   {
     // Enable the field_validation_legacy module before running database

--- a/docroot/sites/sites.php
+++ b/docroot/sites/sites.php
@@ -98,7 +98,7 @@ $sites['eep.stanford.edu'] = 'gep';
 $sites['energypostdoc.stanford.edu'] = 'sepf';
 $sites['epsci.stanford.edu'] = 'gs';
 $sites['esos.stanford.edu'] = 'environmentalsocialsci';
-$sites['neza.stanford.edu'] = 'nza';
+$sites['nzea.stanford.edu'] = 'nza';
 $sites['sustainabilityleadership.stanford.edu'] = 'changeleadership';
 $sites['understand-energy.stanford.edu'] = 'understandenergy';
 


### PR DESCRIPTION
# Summary
- The `field_validation_legacy` module needs to be enabled before database updates run
- The pre-command for the hook I added was incorrect and needed to be changed.
