### PR TITLE
Sdss 1349 sunetid field

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_research_interests
     - field.field.node.stanford_person.su_person_scholarly_interests
     - field.field.node.stanford_person.su_person_short_title
+    - field.field.node.stanford_person.su_person_sunetid
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
     - field.field.node.stanford_person.su_sdss_person_alt_bio
@@ -346,6 +347,14 @@ content:
   su_person_short_title:
     type: string_textfield
     weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  su_person_sunetid:
+    type: string_textfield
+    weight: 54
     region: content
     settings:
       size: 60

--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.field.node.stanford_person.su_person_sunetid.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.field.node.stanford_person.su_person_sunetid.yml
@@ -1,0 +1,19 @@
+uuid: bca588ab-256f-463c-a14e-cf74d0629e26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_person_sunetid
+    - node.type.stanford_person
+id: node.stanford_person.su_person_sunetid
+field_name: su_person_sunetid
+entity_type: node
+bundle: stanford_person
+label: 'SUNet ID'
+description: 'Stanford University SUNet ID, unique to each Stanford affiliate'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.node.su_person_sunetid.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.node.su_person_sunetid.yml
@@ -1,0 +1,21 @@
+uuid: 41de2a70-5018-4458-ac0c-3a1d3f34621e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.su_person_sunetid
+field_name: su_person_sunetid
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/sdss/sdss_profile/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -144,6 +144,7 @@ process:
       default_value: 1
   status: constants/status
   type: constants/type
+  su_person_sunetid: uid
   su_person_first_name: first_name
   su_person_last_name: last_name
   su_person_full_title/value: long_title
@@ -321,6 +322,7 @@ destination:
     - su_person_scholarly_interests/format
     - su_person_scholarly_interests/value
     - su_person_short_title
+    - su_person_sunetid
     - su_person_telephone
     - title
     - type

--- a/docroot/profiles/sdss/sdss_profile/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -144,7 +144,7 @@ process:
       default_value: 1
   status: constants/status
   type: constants/type
-  su_person_sunetid: uid
+  su_person_sunetid: sunetid
   su_person_first_name: first_name
   su_person_last_name: last_name
   su_person_full_title/value: long_title


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds a plaintext field su_person_sunetid to the Person content type and includes it in the Person importer migration configuration.

# Review By asap - required for workgroup auto-tagging

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. drush cim
3. run person importer
4. see if sunet field is set
