### PR TITLE
SDSS-1445: Remove intranet search results test

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Users/IntranetCest.php
+++ b/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Users/IntranetCest.php
@@ -116,38 +116,6 @@ class IntranetCest {
   }
 
   /**
-   * Content should be indexed and results displayed.
-   */
-  public function testSearchResults(AcceptanceTester $I) {
-    $I->runDrush('sset stanford_intranet 1');
-    $I->runDrush('sapi-c');
-    $quote = 'Life is like a box of chocolates. You never know what you’re going to get.';
-    $text_area = $I->createEntity([
-      'type' => 'stanford_wysiwyg',
-      'su_wysiwyg_text' => [
-        [
-          'value' => "<p>$quote</p>",
-          'format' => 'stanford_html',
-        ],
-      ],
-    ], 'paragraph');
-    $node = $I->createEntity([
-      'title' => 'Forest Gump',
-      'type' => 'stanford_page',
-      'su_page_components' => [
-        'target_id' => $text_area->id(),
-        'target_revision_id' => $text_area->getRevisionId(),
-      ],
-    ]);
-    $I->runDrush('sapi-i');
-    $I->logInWithRole('authenticated');
-    $I->amOnPage($node->toUrl()->toString());
-    $I->canSee($quote);
-    $I->amOnPage('/search?key=chocolate');
-    $I->canSeeLink('Forest Gump');
-  }
-
-  /**
    * Files can only be added when allow_file_uploads state is enabled.
    */
   public function testMediaAccess(AcceptanceTester $I) {


### PR DESCRIPTION
# Summary
- Follow up to #560 
- Need to drop the test for the Intranet Search because it no longer works.