### PR TITLE
SDSS-460: Enable the URL alias field on News, Events, and People node forms

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_event.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_event.default.yml
@@ -42,6 +42,7 @@ dependencies:
     - link
     - media_library
     - paragraphs
+    - path
     - readonly_field_widget
     - scheduler
     - smart_date
@@ -156,6 +157,12 @@ content:
   layout_builder__layout:
     type: null
     weight: 26
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -449,7 +456,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  path: true
   promote: true
   su_metatags: true
   syndication: true

--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.field.node.stanford_news.layout_builder__layout
     - field.field.node.stanford_news.stanford_intranet__access
-    - field.field.node.stanford_news.su_sdss_imported_news_sharing
     - field.field.node.stanford_news.su_metatags
     - field.field.node.stanford_news.su_news_banner
     - field.field.node.stanford_news.su_news_banner_media_caption
@@ -18,6 +17,7 @@ dependencies:
     - field.field.node.stanford_news.su_news_topics
     - field.field.node.stanford_news.su_sdss_explore_more_picker
     - field.field.node.stanford_news.su_sdss_import_source
+    - field.field.node.stanford_news.su_sdss_imported_news_sharing
     - field.field.node.stanford_news.su_sdss_media_contacts
     - field.field.node.stanford_news.su_sdss_media_mention
     - field.field.node.stanford_news.su_sdss_news_banner_caption
@@ -40,6 +40,7 @@ dependencies:
     - link
     - media_library
     - metatag
+    - path
     - scheduler
     - stanford_intranet
     - text
@@ -133,6 +134,12 @@ targetEntityType: node
 bundle: stanford_news
 mode: default
 content:
+  path:
+    type: path
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
     weight: 12
@@ -389,7 +396,6 @@ hidden:
   created: true
   layout_builder__layout: true
   layout_selection: true
-  path: true
   promote: true
   sticky: true
   su_news_dek: true

--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -51,6 +51,7 @@ dependencies:
     - media_library
     - menu_link
     - metatag
+    - path
     - scheduler
     - stanford_intranet
     - text
@@ -156,18 +157,30 @@ content:
     third_party_settings: {  }
   field_menulink:
     type: menu_link_default
-    weight: 53
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  layout_builder__layout:
+    type: null
+    weight: 26
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 52
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 50
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -186,7 +199,7 @@ content:
     third_party_settings: {  }
   su_metatags:
     type: metatag_firehose
-    weight: 32
+    weight: 9
     region: content
     settings:
       sidebar: true
@@ -205,7 +218,9 @@ content:
     weight: 7
     region: content
     settings:
+      view_mode: default
       preview_view_mode: default
+      form_display_mode: default
       nesting_depth: 0
       require_layouts: 1
       empty_message: ''
@@ -370,7 +385,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_alt_bio:
     type: text_textarea
-    weight: 36
+    weight: 14
     region: content
     settings:
       rows: 5
@@ -378,7 +393,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_alt_title:
     type: text_textarea
-    weight: 35
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -399,7 +414,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_organization:
     type: cshs
-    weight: 32
+    weight: 10
     region: content
     settings:
       save_lineage: false
@@ -412,7 +427,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_research_area:
     type: cshs
-    weight: 33
+    weight: 11
     region: content
     settings:
       save_lineage: false
@@ -425,7 +440,7 @@ content:
     third_party_settings: {  }
   su_sdss_person_research_state:
     type: text_textarea
-    weight: 34
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -433,7 +448,7 @@ content:
     third_party_settings: {  }
   su_sdss_related_content:
     type: entity_reference_autocomplete
-    weight: 53
+    weight: 18
     region: content
     settings:
       match_operator: CONTAINS
@@ -443,7 +458,7 @@ content:
     third_party_settings: {  }
   su_shared_tags:
     type: cshs
-    weight: 31
+    weight: 8
     region: content
     settings:
       save_lineage: false
@@ -464,8 +479,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  layout_builder__layout: true
-  path: true
   promote: true
   sticky: true
   su_person_academic_appt: true


### PR DESCRIPTION
# Summary
[SDSS-460](https://stanfordits.atlassian.net/browse/SDSS-460): Enable URL alias editing for News, Events, People
- Enabled the URL alias field on News, Events, and People node forms

[SDSS-460]: https://stanfordits.atlassian.net/browse/SDSS-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ