### PR TITLE
SDSS-1496: Add more filters to Past Events list paragraph

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_events.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.stanford_events.yml
@@ -4662,7 +4662,12 @@ display:
           validate_options: {  }
           depth: '1'
           vocabularies:
+            event_audience: event_audience
             sdss_event_topics: sdss_event_topics
+            sdss_focal_areas: sdss_focal_areas
+            stanford_event_groups: stanford_event_groups
+            stanford_event_keywords: stanford_event_keywords
+            stanford_event_subject: stanford_event_subject
             stanford_event_types: stanford_event_types
             su_shared_tags: su_shared_tags
           break_phrase: 1


### PR DESCRIPTION
# Summary
[SDSS-1496](https://stanfordits.atlassian.net/browse/SDSS-1496): Add additional vocabularies to Past Events list display filter
- Added more vocabularies to the Past Events list paragraph display: Event Audience, Focal Areas, Event Departments & Groups, Event Keywords and Tags, Event Subject


[SDSS-1496]: https://stanfordits.atlassian.net/browse/SDSS-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ