### PR TITLE
Added database copying automation and ADR's

### DIFF
--- a/.github/workflows/copy_dbs_to_staging.yml
+++ b/.github/workflows/copy_dbs_to_staging.yml
@@ -1,0 +1,32 @@
+# .github/workflows/copy_dbs_to_staging.yml
+# Copies the databases from proudction sites to staging sites. This workflow
+# is triggered manually and is not triggerged by any events or other workflows.
+# Typical use case is to copy databases to testing at the beginning of a code
+# freeze and QA review.
+name: Copy Production Databases to Staging
+on: workflow_dispatch
+jobs:
+  Copy-Prod-Database-Down:
+    runs-on: ubuntu-latest
+    container:
+      image: pookmish/drupal8ci:php8.3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+            docroot/core
+            docroot/libraries
+            docroot/modules/contrib
+          key: 1.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
+      - name: Copy databases
+        env:
+          SLACK_NOTIFICATION_URL: ${{ secrets.SLACK_NOTIFICATION_URL }}
+          ACQUIA_KEY: ${{ secrets.ACQUIA_KEY }}
+          ACQUIA_SECRET: ${{ secrets.ACQUIA_SECRET }}
+        run: |
+          composer install -n &&
+          blt blt:telemetry:disable --no-interaction &&
+          blt stage --no-interaction

--- a/.github/workflows/copy_dbs_to_staging.yml
+++ b/.github/workflows/copy_dbs_to_staging.yml
@@ -1,5 +1,5 @@
 # .github/workflows/copy_dbs_to_staging.yml
-# Copies the databases from proudction sites to staging sites. This workflow
+# Copies the databases from production sites to staging sites. This workflow
 # is triggered manually and is not triggerged by any events or other workflows.
 # Typical use case is to copy databases to testing at the beginning of a code
 # freeze and QA review.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ The ACE SDSSGryphon stack serves the Doerr School of Sustainability. This stack 
 The primary theme for SDSS is the `sdss_subtheme` located in the `sdss_profile`.
 
 ----
+# ADR's
+
+This site uses Architecture Decision Records to record important technical decisions and the context surrounding them. ADR's can be found in [docs/architecture/decisions](docs/architecture/decisions/). For more information see [0. Record architecture decisions](docs/architecture/decisions/0000-record-architecture-decisions.md).
+
+----
 # GitPod Setup
 1. Add your ssh key to [GitPod](https://gitpod.io/variables)
    1. It is recommended to have a password-less ssh key for simplicity.
@@ -104,28 +109,6 @@ No other prerequisites are necessary, though you may find it helpful to have PHP
 
 
 ---
-## Other Local Setup Steps
-
-1. Set up frontend build and theme.
-By default BLT sets up a site with the lightning profile and a cog base theme. You can choose your own profile before setup in the blt.yml file. If you do choose to use cog, see [Cog's documentation](https://github.com/acquia-pso/cog/blob/8.x-1.x/STARTERKIT/README.md#create-cog-sub-theme) for installation.
-See [BLT's Frontend docs](https://docs.acquia.com/blt/developer/frontend/) to see how to automate the theme requirements and frontend tests.
-After the initial theme setup you can configure `blt/blt.yml` to install and configure your frontend dependencies with `blt setup`.
-
-2. Pull Files locally.
-Use BLT to pull all files down from your Cloud environment.
-
-   ```
-   $ blt drupal:sync:files
-   ```
-
-3. Sync the Cloud Database.
-If you have an existing database you can use BLT to pull down the database from your Cloud environment.
-   ```
-   $ blt sync
-   ```
-
-
----
 
 # Resources
 
@@ -133,11 +116,6 @@ Additional [BLT documentation](https://docs.acquia.com/blt/) may be useful. You 
 ```
 $ blt
 ```
-
-Note the following properties of this project:
-* Primary development branch: 1.x
-* Local environment: @default.local
-* Local site URL: http://local.example.loc/
 
 ## Working With a BLT Project
 
@@ -151,7 +129,6 @@ BLT uses a number of configuration (`.yml` or `.json`) files to define and custo
 
 * `blt/blt.yml` (formerly blt/project.yml prior to BLT 9.x)
 * `blt/local.blt.yml` (local only specific blt configuration)
-* `box/config.yml` (if using Drupal VM)
 * `drush/sites` (contains Drush aliases for this project)
 * `composer.json` (includes required components, including Drupal Modules, for this project)
 

--- a/docs/architecture/decisions/0000-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0000-record-architecture-decisions.md
@@ -1,0 +1,22 @@
+# 0. Record architecture decisions
+
+## Status
+
+Accepted
+
+## Context
+
+We are going to start using ADR's in the repo to record major architecture decisions. We needed to evaluate what process we were going to use and where to put them.
+
+## Decision
+
+We decided to start by using the [Lightweight Architecture Decisions](https://github.com/peter-evans/lightweight-architecture-decision-records) framework for ADR's.
+
+## Consequences
+
+A new `/docs/architecture/decisions` directory has been added to store ADR's. ADR's will also become a part of our regular process and should be included in any PR's with major architecture changes.
+
+## More Information
+
+- [Lightweight Architecture Decisions Repo](https://github.com/peter-evans/lightweight-architecture-decision-records)
+- [ADR template](https://github.com/peter-evans/lightweight-architecture-decision-records/blob/master/0001-ladr-template.md)

--- a/docs/architecture/decisions/0001-automate-database-copy-updates.md
+++ b/docs/architecture/decisions/0001-automate-database-copy-updates.md
@@ -1,0 +1,19 @@
+# 1. Automate database copy updates
+
+## Status
+
+Accepted
+
+## Context
+
+Copying databases down from production to staging and then running updates across all staging sites was a manual and time consuming process for a developer. To improve workflows we want to run updates automatically when a database is copied and offload the database copying process.
+
+## Decision
+
+- Add code in the `post-db-copy` cloud hook to run updates on a site after a database has been copied on any environment. 
+- Add a Github actions workflow to copy production databases to staging. This workflow will be triggered manually from the Actions tab on Github.
+
+## Consequences
+
+- Database updates and configuration imports will be performed automatically when a database is copied or restored on any environment. 
+- Developers can perform the database copying from production to staging by clicking a button.

--- a/hooks/common/post-db-copy/post-db-copy.sh
+++ b/hooks/common/post-db-copy/post-db-copy.sh
@@ -19,6 +19,9 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --no-interaction -D drush.ansi=false
+#blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --no-interaction -D drush.ansi=false
+# Run the BLT command to run deploy hooks, including updating the database and
+# importing configuration.
+blt artifact:update:drupal --site=$db_name --environment=$target_env
 
 set +v

--- a/hooks/common/post-db-copy/post-db-copy.sh
+++ b/hooks/common/post-db-copy/post-db-copy.sh
@@ -19,9 +19,12 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
+# This command is the default and only runs updates if the site is on an ODE
+# environment.
 #blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --no-interaction -D drush.ansi=false
+
 # Run the BLT command to run deploy hooks, including updating the database and
-# importing configuration.
+# importing configuration, on the target environment and site.
 blt artifact:update:drupal --site=$db_name --environment=$target_env
 
 set +v


### PR DESCRIPTION
#  READY FOR REVIEW

# Summary
- Added code in `post-db-copy` cloud hook to run updates on a site after database has been copied.
- Added Github actions workflow to copy production databases to staging. This workflow is triggered manually from the Actions tab on Github.
- Currently copying databases down from production to staging and then running updates across all staging sites were manual and time consuming processes for a developer. With these changes, the developer only needs to trigger the workflow and Github will do the rest.
- Also added ADR's to this repo.
