### PR TITLE
SDSS-1347: Add Workgroup Tagging settings to config_readonly whitelist

### DIFF
--- a/docroot/sites/settings/global.settings.php
+++ b/docroot/sites/settings/global.settings.php
@@ -53,7 +53,8 @@ if (EnvironmentDetector::isAhEnv()) {
       'stanford_earth_r25.adminsettings',
       'stanford_earth_r25.credentialsettings',
       'stanford_earth_r25.stanford_earth_r25.*',
-      'sdss_news_sharing.*'
+      'sdss_news_sharing.*',
+      'sdss_workgroup_tagging.settings'
     ];
     $settings['config_readonly_content_link_providers'] = [
       'menu_link_content',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
  Adds sdss_workgroup_tagging.settings to config_readonly whitelist to allow live site configuration.

# Review By (Date)
- ASAP

