### PR TITLE
SDSS-856: Add field to conditionally hide the editorial sidebar title

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.paragraph.editorial_sidebar.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_form_display.paragraph.editorial_sidebar.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.editorial_sidebar.su_hide_sidebar_title
     - field.field.paragraph.editorial_sidebar.su_sidebar_bgcolor_alt
     - field.field.paragraph.editorial_sidebar.su_sidebar_body
     - field.field.paragraph.editorial_sidebar.su_sidebar_title
@@ -15,6 +16,13 @@ targetEntityType: paragraph
 bundle: editorial_sidebar
 mode: default
 content:
+  su_hide_sidebar_title:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   su_sidebar_bgcolor_alt:
     type: options_select
     weight: 0
@@ -23,7 +31,7 @@ content:
     third_party_settings: {  }
   su_sidebar_body:
     type: text_textarea
-    weight: 3
+    weight: 4
     region: content
     settings:
       rows: 5

--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_view_display.paragraph.editorial_sidebar.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_view_display.paragraph.editorial_sidebar.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.editorial_sidebar.su_hide_sidebar_title
     - field.field.paragraph.editorial_sidebar.su_sidebar_bgcolor_alt
     - field.field.paragraph.editorial_sidebar.su_sidebar_body
     - field.field.paragraph.editorial_sidebar.su_sidebar_title
@@ -64,3 +65,4 @@ content:
     region: content
 hidden:
   search_api_excerpt: true
+  su_hide_sidebar_title: true

--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.field.paragraph.editorial_sidebar.su_hide_sidebar_title.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.field.paragraph.editorial_sidebar.su_hide_sidebar_title.yml
@@ -1,0 +1,21 @@
+uuid: 6463dfe9-d210-46df-8496-ead7bf9692e3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_hide_sidebar_title
+    - paragraphs.paragraphs_type.editorial_sidebar
+id: paragraph.editorial_sidebar.su_hide_sidebar_title
+field_name: su_hide_sidebar_title
+entity_type: paragraph
+bundle: editorial_sidebar
+label: 'Hide Sidebar Title'
+description: 'Hide the sidebar title visually. The title will remain for screen readers. It is important to provide a relevant and descriptive title, even if it is hidden from visual display.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.field.paragraph.editorial_sidebar.su_sidebar_title.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.field.paragraph.editorial_sidebar.su_sidebar_title.yml
@@ -13,7 +13,7 @@ field_name: su_sidebar_title
 entity_type: paragraph
 bundle: editorial_sidebar
 label: 'Editorial sidebar title'
-description: 'Please add a title for the Editorial sidebar.'
+description: 'Please add a title for the Editorial sidebar. <strong>It is important to provide a relevant and descriptive title, even if it is hidden from visual display.</strong>'
 required: true
 translatable: true
 default_value: {  }

--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.paragraph.su_hide_sidebar_title.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.storage.paragraph.su_hide_sidebar_title.yml
@@ -1,0 +1,18 @@
+uuid: 90a0f176-56ea-4523-be16-47da41d790f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.su_hide_sidebar_title
+field_name: su_hide_sidebar_title
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/templates/components/newsroom-sidebar/paragraph--editorial-sidebar.html.twig
+++ b/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/templates/components/newsroom-sidebar/paragraph--editorial-sidebar.html.twig
@@ -4,6 +4,6 @@
 {%- set attributes = attributes.addClass(['sidebar', background_color, selectedFontSize]) -%}
 
 <aside {{ attributes }}>
-    {{ content.su_sidebar_title }}
+    {{ content.su_sidebar_title|add_class(paragraph.su_hide_sidebar_title.value ? 'visually-hidden' : '') }}
     {{ content.su_sidebar_body }}
 </aside>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-856](https://stanfordits.atlassian.net/browse/SDSS-856): Add option to Editorial Sidebar to hide the title
- Added a field to conditionally hide the editorial sidebar title.
- Added help text to inform the user on the importance of adding a relevant title, even if it won't be display visually.


[SDSS-856]: https://stanfordits.atlassian.net/browse/SDSS-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ