### PR TITLE
SDSS-1503: Set default theme and enable theme settings for sustainability site via database update

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -71,8 +71,6 @@ function sdss_profile_update_10019() {
   // The site folder is usually the second part (e.g., 'sites/sustainability').
   $site_name = isset($site_path_parts[1]) ? $site_path_parts[1] : '';
 
-  var_dump($site_name);
-
   if ($site_name === 'sustainability') {
     // Set the default theme.
     \Drupal::configFactory()->getEditable('system.theme')


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-1503](https://stanfordits.atlassian.net/browse/SDSS-1503): Update database
- Sets Sustainability site them to `sdss_subtheme` and enables the `desktop_hamburger` and `display_utility_navigation` theme settings.

[SDSS-1503]: https://stanfordits.atlassian.net/browse/SDSS-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ