### PR TITLE
SDSS-0000 Update stanford_earth_r25 module to 8.x-1.17.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
             "type": "package",
             "package": {
                 "name": "stanford-earth/stanford_earth_r25",
-                "version": "8.1.16",
+                "version": "8.1.17",
                 "type": "drupal-custom-module-rooms-site",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/stanford-earth/stanford_earth_r25",
-                    "reference": "8.1.16"
+                    "reference": "8.1.17"
                 }
             }
         },


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Minor fixes for room reservation handling of 25Live custom attributes for Farm locations.

# Review By 07/16/2025

# Criticality
To be included if possible for 7/16/2025 production push

# Review Tasks
Still unable to run 'composer update' on UIT loaner laptop. Please include new module version of stanford_earth_r25 in production build.
