### PR TITLE
SDSS-1539: Map sdss:webdev Workgroup to Administrator Role for All Sites

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_roles.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_roles.yml
@@ -16,6 +16,8 @@ translatable: false
 default_value:
   -
     value: 'administrator:eduPersonEntitlement,=,uit:sws'
+  -
+    value: 'administrator:eduPersonEntitlement,=,sdss:webdev'
 default_value_callback: ''
 settings: {  }
 field_type: string_long

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -89,3 +89,33 @@ function sdss_profile_update_10019() {
     \Drupal::logger('sdss_profile')->info('Default and active theme set to sdss_subtheme for sustainability site. Theme settings desktop_hamburger and display_utility_navigation enabled.');
   }
 }
+
+/**
+ * Add sdss:webdev role mapping.
+ *
+ * This update adds a new role mapping to the su_simplesaml_roles configuration
+ * on the stanford_saml config page. It maps the 'administrator' role to users
+ * with the 'eduPersonEntitlement' attribute containing 'sdss:webdev'.
+ */
+function sdss_profile_update_10020() {
+  $config_page = \Drupal::entityTypeManager()
+    ->getStorage('config_pages')
+    ->load('stanford_saml');
+  if ($config_page) {
+    $roles = $config_page->get('su_simplesaml_roles') ?: '';
+    $mappings = array_filter(explode('|', is_object($roles) && method_exists($roles, 'getString') ? $roles->getString() : (string) $roles));
+    $new_mapping = 'administrator:eduPersonEntitlement,=,sdss:webdev';
+    if (!in_array($new_mapping, $mappings)) {
+      $mappings[] = $new_mapping;
+      $config_page->set('su_simplesaml_roles', implode('|', $mappings));
+      $config_page->save();
+      \Drupal::logger('sdss_profile')->info('Mapping added to su_simplesaml_roles by update_10020.');
+    }
+    else {
+      \Drupal::logger('sdss_profile')->info('Mapping already present in su_simplesaml_roles by update_10020.');
+    }
+  }
+  else {
+    \Drupal::logger('sdss_profile')->warning('stanford_saml config page not found in update_10020.');
+  }
+}

--- a/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Users/RoleMappingsCest.php
+++ b/docroot/profiles/sdss/sdss_profile/tests/codeception/acceptance/Users/RoleMappingsCest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Class RoleMappingsCest.
+ *
+ * @group users
+ */
+class RoleMappingsCest {
+
+  /**
+   * Test that the correct role mappings exist on the SAML config page.
+   */
+  public function testRoleMappingInConfig(AcceptanceTester $I) {
+    // Log in as an administrator.
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/admin/config/people/stanford-saml');
+    // Check that the mapping is visible on the page.
+    $I->canSee('uit:sws');
+    $I->canSee('sdss:webdev');
+  }
+
+}


### PR DESCRIPTION
# Summary
This PR ensures that the `sdss:webdev` workgroup is mapped to the `administrator` role for all sites using the sdss_profile.
- Adds a database update to append the mapping for existing sites.
- Updates the default value for new installs.
- Adds an acceptance test to verify both `uit:sws` and `sdss:webdev` mappings are present on the SAML config page.

# Criticality
- 7/10: Affects all sites using sdss_profile and SAML role mapping.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch.
2. Run `drush updb` and confirm no errors.
3. Log in as an administrator and visit `/admin/config/people/stanford-saml`.
4. Confirm both `uit:sws` and `sdss:webdev` mappings are present.
5. Run Codeception acceptance tests and confirm the new test passes.
6. (Optional) Install a new site and confirm both mappings are present by default.

## Backend / Functional Validation
### Code
- [x] Are the naming conventions following our standards?
- [x] Does the code have sufficient inline comments?
- [x] Is there anything in this code that would be hidden or hard to discover through the UI?
- [x] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [x] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [x] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)? (N/A)
- [x] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)? (N/A)

## General
- [x] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [x] Is the approach to the problem appropriate?

# Affected Projects or Products
- All sites using sdss_profile and SAML role mapping.

# Associated Issues and/or People
- JIRA ticket: [SDSS-1539](https://stanfordits.atlassian.net/browse/SDSS-1539)
- No other PRs or related issues.
- No additional notifications.

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)


[SDSS-1539]: https://stanfordits.atlassian.net/browse/SDSS-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ