### PR TITLE
SDSS-1542: Update events XML feed

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/views.view.events_feeds.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/views.view.events_feeds.yml
@@ -23,6 +23,7 @@ dependencies:
     - node
     - rest
     - serialization
+    - smart_date
     - user
 id: events_feeds
 label: 'Events Feeds'
@@ -1400,6 +1401,52 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        su_event_date_time_value:
+          id: su_event_date_time_value
+          table: node__su_event_date_time
+          field: su_event_date_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '-1 year'
+            type: date
+            granularity: second
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: serializer
       row:


### PR DESCRIPTION
## Summary
The Events XML feed used for calendaring in Smartsheet was broken due to pulling too many events (no filter). Aaron updated the view on the dev site to add a date filter, so events older than 1 year no longer appear. This PR updates the configuration in the codebase.

## Criticality
- 6/10. This affects the sustainability site calendar integration with Smartsheet.

## Review Tasks

### Setup tasks and/or behavior to test
1. Check out this branch
2. Import the updated configuration
3. Verify that the events feed at `/admin/structure/views/view/events_feeds` only shows events from the past year

### Front End Validation
- [x] Markup and HTML validation not applicable
- [x] No front-end changes

### Backend / Functional Validation
- [x] Naming conventions and comments are standard
- [x] No code smells
- [x] Configuration change only
- [x] No new tests required

### Code security
- [x] No forms affected
- [x] No new security concerns

## General
- [x] Only configuration related to the events feed is changed
- [x] Approach is appropriate

# Associated Issues and/or People
[SDSS-1542](https://stanfordits.atlassian.net/browse/SDSS-1542): Events XML feed is broken

[SDSS-1542]: https://stanfordits.atlassian.net/browse/SDSS-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ