### PR TITLE
SDSS-1530: Remove cron job step from provision documentation

### DIFF
--- a/docs/new-site-provision.md
+++ b/docs/new-site-provision.md
@@ -146,9 +146,6 @@ These steps cannot be completed until the provision code has been merged and dep
 To install a new site with default profile:
 `drush @MACHINE_NAME.prod si sdss_profile -y`
 
-### Create a Cron Job for the Site
-`blt gryphon:create-cron prod MACHINE_NAME`
-
 ### Configure SAML login settings
 Make sure the correct workgroups have the appropriate access to the site.
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates provisioning documentation to remove the step for creating a cron job per site. This reflects the change in SDSS-1530, where a script now runs Drupal cron across all sites, eliminating the need for individual site cron jobs.

# Review By (Date)
- As soon as possible; no strict deadline.

# Criticality
- 3/10. This affects documentation only and does not impact site functionality.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch.
2. Navigate to the updated provisioning documentation.
3. Verify that the step to create a cron job for each site has been removed.

## General
- [ ] The change is limited to documentation and directly related to the problem described in SDSS-1530.
- [ ] The approach is appropriate for the updated provisioning process.

# Associated Issues and/or People
[SDSS-1530](https://stanfordits.atlassian.net/browse/SDSS-1530): Add custom Scheduled Cron Job for Scheduler Job


[SDSS-1530]: https://stanfordits.atlassian.net/browse/SDSS-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ