### PR TITLE
SDSS-1523: Add aria-label to the video banner play and pause button

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/js/scripts.js
+++ b/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/js/scripts.js
@@ -29,9 +29,11 @@
         if (!video.paused) {
           $playPauseButton.addClass('fa-pause');
           $playPauseLabel.text('Pause');
+          $playPauseButton.attr('aria-label', 'Pause video');
         } else {
           $playPauseButton.addClass('fa-play');
           $playPauseLabel.text('Play');
+          $playPauseButton.attr('aria-label', 'Play video');
         }
 
         const $container = $('<div>').addClass('video-info')
@@ -42,9 +44,11 @@
         $video.on('play', function () {
           $playPauseButton.toggleClass('fa-pause').toggleClass('fa-play');
           $playPauseLabel.text('Pause');
+          $playPauseButton.attr('aria-label', 'Pause video');
         }).on('pause', function () {
           $playPauseButton.toggleClass('fa-pause').toggleClass('fa-play');
           $playPauseLabel.text('Play');
+          $playPauseButton.attr('aria-label', 'Play video');
         });
       });
     },


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-1523](https://stanfordits.atlassian.net/browse/SDSS-1523): A11Y: Pause button on home video needs alt text
- Adds dynamic aria-labels to the video banner play/pause button for improved accessibility. The label now updates to "Play video" or "Pause video" based on the button state.

# Review By (Date)
- As soon as possible for accessibility compliance.

# Criticality
- 6/10. Improves accessibility for all users, especially those using screen readers.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Sync the sustainability site locally
3. Navigate to the home page of the local Sustainability site
4. Verify the play/pause button updates its aria-label to "Play video" or "Pause video" as appropriate

[SDSS-1523]: https://stanfordits.atlassian.net/browse/SDSS-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ