### PR TITLE
SDSS-1536: Add body class and restrict paragraph types for Sustainability Home Page

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -14,9 +14,8 @@ function sdss_profile_requirements($phase) {
   $requirements = [];
   if ($phase == 'runtime') {
 
-    $site_path = DrupalKernel::findSitePath(\Drupal::request());
-    $site_path = explode('/', $site_path);
-    $site_name = $site_path[1];
+    $site_path = \Drupal::getContainer()->getParameter('site.path');
+    $site_name = basename($site_path);
 
     $requirements['stanford_site_alias'] = [
       'title' => t('Stanford Site Alias'),

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.profile
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.profile
@@ -36,3 +36,36 @@ function sdss_profile_config_pages_presave(ConfigPages $config_page) {
     \Drupal::service('router.builder')->rebuild();
   }
 }
+
+/**
+ * Implements hook_entity_reference_field_options_alter().
+ *
+ * Limit the available options for the su_page_components field on stanford_page
+ * nodes to only allow certain paragraph types on the front page node.
+ */
+function sdss_profile_entity_reference_field_options_alter(array &$options, array $context) {
+  dpm('test');
+  if (
+    $context['field_definition']->getName() === 'su_page_components' &&
+    $context['entity']->bundle() === 'stanford_page'
+  ) {
+    $node = $context['entity'];
+    dpm($node);
+    // Get the front page node ID from config.
+    $front = \Drupal::config('system.site')->get('page.front');
+    dpm($front);
+    $front_nid = NULL;
+    if ($front && preg_match('/^node\/(\d+)$/', $front, $matches)) {
+      $front_nid = $matches[1];
+    }
+    dpm($front_nid);
+    // Restrict if not the front page node.
+    if ($node->id() != $front_nid) {
+      unset($options['paragraphs.paragraphs_type.su_pinned_background_section']);
+      unset($options['paragraphs.paragraphs_type.su_image_cta']);
+      unset($options['paragraphs.paragraphs_type.su_departments_slider']);
+      unset($options['paragraphs.paragraphs_type.su_horizontal_bar']);
+      unset($options['paragraphs.paragraphs_type.su_header_with_link']);
+    }
+  }
+}

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.services.yml
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.services.yml
@@ -12,3 +12,12 @@ services:
     arguments: ['@state', '@config.factory']
     tags:
       - {name: config.factory.override, priority: -5}
+  sdss_profile.paragraph_restrictions_subscriber:
+    class: 'Drupal\sdss_profile\EventSubscriber\ParagraphRestrictionsSubscriber'
+    arguments:
+      - '@plugin.manager.core.layout'
+      - '@entity_type.manager'
+      - '@config.factory'
+      - '@path_alias.manager'
+    tags:
+      - { name: event_subscriber }

--- a/docroot/profiles/sdss/sdss_profile/src/EventSubscriber/ParagraphRestrictionsSubscriber.php
+++ b/docroot/profiles/sdss/sdss_profile/src/EventSubscriber/ParagraphRestrictionsSubscriber.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Drupal\sdss_profile\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Layout\LayoutPluginManagerInterface;
+use Drupal\layout_paragraphs\Event\LayoutParagraphsAllowedTypesEvent;
+use Drupal\path_alias\AliasManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Custom restrictions on paragraph types.
+ * 
+ * Paragraph type restrictions based on layouts and regions belong in the layout
+ * definitions in sdss_layout_paragraphs. This implementation restricts based
+ * on other contexts.
+ */
+class ParagraphRestrictionsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The layout manager.
+   *
+   * @var \Drupal\Core\Layout\LayoutPluginManagerInterface
+   */
+  protected $layoutManager;
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The path alias manager.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      LayoutParagraphsAllowedTypesEvent::EVENT_NAME => 'layoutParagraphsAllowedTypes',
+    ];
+  }
+
+  /**
+   * Constructs a new ParagraphRestrictionsSubscriber.
+   *
+   * @param \Drupal\Core\Layout\LayoutPluginManagerInterface $layout_manager
+   *   The layout manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Path\AliasManagerInterface $alias_manager
+   *   The path alias manager.
+   */
+  public function __construct(
+    LayoutPluginManagerInterface $layout_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    ConfigFactoryInterface $config_factory,
+    AliasManagerInterface $alias_manager
+  ) {
+    $this->layoutManager = $layout_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
+    $this->aliasManager = $alias_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create($container) {
+    return new static(
+      $container->get('plugin.manager.core.layout'),
+      $container->get('entity_type.manager'),
+      $container->get('config.factory'),
+      $container->get('path_alias.manager')
+    );
+  }
+
+  /**
+   * Adjust the paragraphs allowed in the layout paragraphs widget.
+   *
+   * @param \Drupal\layout_paragraphs\Event\LayoutParagraphsAllowedTypesEvent $event
+   *   Layout paragraphs event.
+   */
+  public function layoutParagraphsAllowedTypes(LayoutParagraphsAllowedTypesEvent $event): void {
+    // Paragraph types only allowed on the Sustainability site home page.
+    $sustainability_home_paragraphs = [
+      'su_pinned_background_section',
+      'su_image_cta',
+      'su_departments_slider',
+      'su_horizontal_bar',
+      'su_header_with_link',
+    ];
+
+    // Unset paragraph types if not on the Sustainability site.
+    if ($this->isSustainabilitySite() === FALSE) {
+      $types = $this->unsetParagraphTypes($event->getTypes(), $sustainability_home_paragraphs);
+      $event->setTypes($types);
+      return;
+    }
+    
+    // Unset paragraph types if not on the home page.
+    if ($this->isFrontPage($event->getParentUuid()) === FALSE) {
+      $types = $this->unsetParagraphTypes($event->getTypes(), $sustainability_home_paragraphs);
+      $event->setTypes($types);
+      return;
+    }
+  }
+
+  /**
+   * Removes specified paragraph types from the allowed types array.
+   *
+   * @param array $types
+   *   The allowed paragraph types.
+   * @param array $unset_paragraphs
+   *   The paragraph type machine names to remove.
+   *
+   * @return array
+   *   The filtered allowed paragraph types.
+   */
+  protected function unsetParagraphTypes(array $types, array $unset_paragraphs): array {
+    foreach ($unset_paragraphs as $paragraph_type) {
+      unset($types[$paragraph_type]);
+    }
+    return $types;
+  }
+
+  /**
+   * Checks if the current site is the sustainability site.
+   *
+   * @return bool
+   *   TRUE if the site is 'sustainability', FALSE otherwise.
+   */
+  protected function isSustainabilitySite(): bool {
+    $site_path = \Drupal::getContainer()->getParameter('site.path');
+    $site_name = basename($site_path);
+    return $site_name === 'sustainability';
+  }
+  
+  /**
+   * Checks if the parent node of the given paragraph UUID is the front page
+   * node.
+   *
+   * @param string $parent_uuid
+   *   The UUID of the parent paragraph entity.
+   *
+   * @return bool
+   *   TRUE if the parent node is the front page node, FALSE otherwise.
+   */
+  protected function isFrontPage(string $parent_uuid): bool {
+    $paragraph_storage = $this->entityTypeManager->getStorage('paragraph');
+    $paragraphs = $paragraph_storage->loadByProperties(['uuid' => $parent_uuid]);
+    $paragraph = reset($paragraphs);
+
+    $node_id = NULL;
+    if (
+      $paragraph && 
+      $paragraph->getParentEntity() && 
+      $paragraph->getParentEntity()->getEntityTypeId() === 'node'
+    ) {
+      $node = $paragraph->getParentEntity();
+      $node_id = $node->id();
+    }
+
+    $front_nid = NULL;
+    $front = $this->configFactory->get('system.site')->get('page.front');
+    if ($front && preg_match('/^\/?node\/(\d+)$/', $front, $matches)) {
+      $front_nid = $matches[1];
+    } else {
+      $system_path = $this->aliasManager->getPathByAlias($front);
+      if (preg_match('/^\/?node\/(\d+)$/', $system_path, $matches)) {
+        $front_nid = $matches[1];
+      }
+    }
+
+    if (!isset($node_id) || !isset($front_nid) || $node_id != $front_nid) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+}

--- a/docroot/profiles/sdss/sdss_profile/tests/src/Kernel/EventSubscriber/EventSubscriberTest.php
+++ b/docroot/profiles/sdss/sdss_profile/tests/src/Kernel/EventSubscriber/EventSubscriberTest.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\Tests\sdss_profile\Kernel\EventSubscriber;
 
-use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
 use Drupal\consumers\Entity\Consumer;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\default_content\Event\ImportEvent;
 use Drupal\file\Entity\File;
@@ -13,10 +11,6 @@ use Drupal\media\Entity\Media;
 use Drupal\media\Entity\MediaType;
 use Drupal\sdss_profile\EventSubscriber\EventSubscriber as StanfordEventSubscriber;
 use Drupal\user\Entity\Role;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Class EventSubscriberTest.

--- a/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/sdss_subtheme.theme
+++ b/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/sdss_subtheme.theme
@@ -5,7 +5,6 @@
  * sdss_subtheme.theme
  */
 
-use Drupal\Core\DrupalKernel;
 use Drupal\node\NodeInterface;
 
 /**

--- a/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/sdss_subtheme.theme
+++ b/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/sdss_subtheme.theme
@@ -5,6 +5,7 @@
  * sdss_subtheme.theme
  */
 
+use Drupal\Core\DrupalKernel;
 use Drupal\node\NodeInterface;
 
 /**
@@ -25,6 +26,20 @@ function sdss_subtheme_preprocess_html(&$variables) {
   // Variant setting for the header layout.
   if ($header_layout_variant = theme_get_setting('header_layout_variant')) {
     $variables['attributes']['class'][] = 'sdss-header-variant--' . $header_layout_variant;
+  }
+
+  // Add body class to the front page of the Sustainability site.
+  $is_front = \Drupal::service('path.matcher')->isFrontPage();
+  $is_sustainability = FALSE;
+
+  $site_path = \Drupal::getContainer()->getParameter('site.path');
+  $site_name = basename($site_path);
+  if ($site_name === 'sustainability') {
+    $is_sustainability = TRUE;
+  }
+
+  if ($is_front && $is_sustainability) {
+    $variables['attributes']['class'][] = 'sustainability-homepage';
   }
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
[SDSS-1563](https://stanfordits.atlassian.net/browse/SDSS-1563): Changes to support new Sustainability Home Page
- Adds a custom body class to the Sustainability homepage for targeted styling.
- Restricts specific Paragraph types to only be available on the Sustainability homepage using an event subscriber.

# Review By (Date)
- ASAP

# Criticality
- 10/10: Required to hit deadline of deployment on 9/22.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch: `SDSS-1563--homepage-support-changes`
1. Sync the Sustainability site locally.
2. Navigate to the Sustainability site homepage in the browser.
3. Inspect the `<body>` tag and verify the custom class is present only on the homepage.
4. Edit the homepage in the backend and verify the restricted Paragraph types are available.
5. Edit any other page and verify the restricted Paragraph types are NOT available
6. Sync a separate site or install a fresh default site.
7. Edit any page and verify the restricted Paragraph types are NOT available
3. Inspect the `<body>` tag and verify the custom class is NOT present on the homepage.

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
