### PR TITLE
SDSS-1593: Enable "Block Search Engines" (nobots) by Default on New Sites

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/src/Plugin/InstallTask/SiteSettings.php
+++ b/docroot/profiles/sdss/sdss_profile/src/Plugin/InstallTask/SiteSettings.php
@@ -70,7 +70,7 @@ class SiteSettings extends InstallTaskBase implements ContainerFactoryPluginInte
    * {@inheritDoc}
    */
   public function runTask(array &$install_state) {
-    $this->state->set('nobots', FALSE);
+    $this->state->set('nobots', TRUE);
 
     $node_pages = [
       '403_page' => '4b8018dc-49a6-4018-9c54-e8c3e462beee',


### PR DESCRIPTION
# Summary
- This PR updates the SDSS profile's install task to enable the "Block Search Engines" (nobots) setting by default on new site installations. Previously, this was disabled by default. This change aligns with the [Stanford Sites default as of February 2025](https://github.com/SU-SWS/stanford_profile/pull/871/files#diff-caec271b9143d5c05928ea2da162c00c9ce4f65271d7f08ffcaea6da6feee579) and ensures new sites are not indexed by search engines until explicitly allowed.
- Type of change: Maintenance / Configuration update

# Criticality
- Criticality: 6/10
- This affects all new SDSS sites created from the profile, ensuring they are not indexed by search engines by default. Existing sites are unaffected.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Install a new site using the SDSS profile
3. After installation, verify that the "Block Search Engines" (nobots) setting is enabled (TRUE) in state

# Related Issues/PR's
[SDSS-1593](https://stanfordits.atlassian.net/browse/SDSS-1593): Enable "Block Search Engines" by default on -prod sites

# Additional Context
- This change follows the Stanford Sites update from February 2025, which enabled nobots by default for new sites.
- The SDSS internal launch guide for developers includes a step to turn nobots off when ready for launch.
- No impact to existing sites; only new installs are affected.


[SDSS-1593]: https://stanfordits.atlassian.net/browse/SDSS-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ