### PR TITLE
SDSS-1372: Remove unwanted taxonomy terms from Basic Page default display

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -60,54 +60,6 @@ third_party_settings:
                 third_party_settings: {  }
             weight: 0
             additional: {  }
-          86eb8bed-61b6-4163-81a5-cb8ab4cd70d3:
-            uuid: 86eb8bed-61b6-4163-81a5-cb8ab4cd70d3
-            region: main
-            configuration:
-              id: 'field_block:node:stanford_page:su_sdss_basic_focal_areas'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 1
-            additional: {  }
-          33053f02-c36f-4c4a-b323-167ec3ac825b:
-            uuid: 33053f02-c36f-4c4a-b323-167ec3ac825b
-            region: main
-            configuration:
-              id: 'field_block:node:stanford_page:su_sdss_basic_organization'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
-            additional: {  }
-          ef47bdc5-5372-483d-b747-287f665cfbed:
-            uuid: ef47bdc5-5372-483d-b747-287f665cfbed
-            region: main
-            configuration:
-              id: 'field_block:node:stanford_page:su_sdss_basic_opportunity_type'
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              formatter:
-                type: entity_reference_label
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_one_column


### PR DESCRIPTION
# Summary
[SDSS-1372](https://stanfordits.atlassian.net/browse/SDSS-1372): Remove Focal Area taxonomy 'breadcrumbs'
Three taxonomy terms got added to the Basic Page content type in #113 . These were unintentionally added to the default display for Basic Pages, when they should not have been displaying. This PR rectifies that.


[SDSS-1372]: https://stanfordits.atlassian.net/browse/SDSS-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ