### PR TITLE
SDSS-0000: Update Workflows to MySQL 8 & Add Default Site Sync Test

### DIFF
--- a/.github/workflows/dependency_updates.yml
+++ b/.github/workflows/dependency_updates.yml
@@ -23,7 +23,7 @@ jobs:
       DRUPAL_DATABASE_HOST: mysql
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -1,0 +1,58 @@
+name: Test Default Site Sync
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+jobs:
+  test_site_sync:
+    runs-on: ubuntu-latest
+    container:
+      image: pookmish/drupal8ci:php8.3
+    env:
+      DRUPAL_DATABASE_NAME: drupal
+      DRUPAL_DATABASE_USERNAME: drupal
+      DRUPAL_DATABASE_PASSWORD: drupal
+      DRUPAL_DATABASE_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: drupal
+          MYSQL_USER: drupal
+          MYSQL_PASSWORD: drupal
+          MYSQL_ROOT_PASSWORD: drupal
+        ports:
+          - 33306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.ACQUIA_SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          if_key_exists: fail
+      - uses: actions/checkout@v4
+      - name: Restore Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+            docroot/core
+            docroot/libraries
+            docroot/modules/contrib
+          key: 4.0-${{ hashFiles('blt/blt.yml') }}-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
+      - run: git config --system --add safe.directory '*'
+      - name: Sync Default Site
+        run: |
+          mysql -h mysql -P 3306 -u root -pdrupal -e 'SET GLOBAL max_allowed_packet=67108864;' &&
+          rm -rf /var/www/html &&
+          ln -snf $GITHUB_WORKSPACE /var/www/html &&
+          ssh-keyscan -t rsa stanfordsos.ssh.prod.acquia-sites.com >> /root/.ssh/known_hosts &&
+          composer install -n &&
+          blt settings &&
+          mkdir -p docroot/sites/default/files &&
+          chmod -R 777 docroot/sites/default/files/ &&
+          blt drupal:sync --site=default -n

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       image: pookmish/drupal8ci:php8.3
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal
@@ -70,7 +70,7 @@ jobs:
         image: selenium/standalone-chrome:latest
         options: '--shm-size="2g"'
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/docroot/sites/default/blt.yml
+++ b/docroot/sites/default/blt.yml
@@ -3,4 +3,4 @@ project:
 drush:
   aliases:
     local: self
-    remote: ace-sdssgryphon.test
+    remote: default.prod


### PR DESCRIPTION
# Summary
- Update all GitHub Actions workflows to use MySQL 8.0 instead of 5.7 for improved compatibility and future-proofing.
- Add a new workflow to test syncing the default Drupal site on every PR, ensuring database updates and config imports are validated automatically.
- Fix the "remote" value in docroot/sites/default/blt.yml to use the correct Acquia environment.
- Type of change: Maintenance, CI/CD improvement, and workflow enhancement.

# Criticality
- 7/10: This affects all PRs and deployments by updating the database version and adding automated site sync testing. It is important for ongoing compatibility and deployment reliability, but does not directly impact production user data.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Review the updated workflows in .github/workflows/ for MySQL 8.0 usage
3. Confirm the new site-sync-test workflow exists and is configured for the default site
4. Ensure docroot/sites/default/blt.yml has the correct remote value (default.prod)
5. Optionally, run `blt drupal:sync --site=default` locally to verify sync works
