### PR TITLE
Taxonomy permission updates for sdss_proj_ and opportunity vocabularies

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_flagships.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_flagships.yml
@@ -21,7 +21,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-name: Flagships
+name: 'Project Flagships'
 vid: sdss_proj_flagships
 description: null
 weight: 0

--- a/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_status.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_status.yml
@@ -21,7 +21,7 @@ third_party_settings:
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-name: Status
+name: 'Project Status'
 vid: sdss_proj_status
 description: null
 weight: 0

--- a/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_topics.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/taxonomy.vocabulary.sdss_proj_topics.yml
@@ -21,7 +21,7 @@ third_party_settings:
     unpublish_revision: false
   flat_taxonomy:
     flat: 1
-name: Topics
+name: 'Project Topics'
 vid: sdss_proj_topics
 description: null
 weight: 0

--- a/docroot/profiles/sdss/sdss_profile/config/sync/user.role.contributor.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/user.role.contributor.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.stanford_event
     - node.type.stanford_event_series
     - node.type.stanford_news
+    - node.type.stanford_opportunity
     - node.type.stanford_page
     - node.type.stanford_person
     - node.type.stanford_policy
@@ -68,8 +69,6 @@ permissions:
   - 'create stanford_page content'
   - 'create stanford_person content'
   - 'create stanford_publication content'
-  - 'create terms in opportunity_sponsor'
-  - 'create terms in opportunity_type'
   - 'create video media'
   - 'delete any stanford_opportunity content'
   - 'delete citation entities'
@@ -90,8 +89,6 @@ permissions:
   - 'delete own stanford_publication content'
   - 'delete own video media'
   - 'delete stanford_opportunity revisions'
-  - 'delete terms in opportunity_sponsor'
-  - 'delete terms in opportunity_type'
   - 'dropzone upload files'
   - 'edit any embeddable media'
   - 'edit any file media'
@@ -127,8 +124,6 @@ permissions:
   - 'edit own video media'
   - 'edit policy log'
   - 'edit sdss entity'
-  - 'edit terms in opportunity_sponsor'
-  - 'edit terms in opportunity_type'
   - 'mark as hidden in editoria11y'
   - 'mark as ok in editoria11y'
   - 'notify of path changes'

--- a/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_builder.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_builder.yml
@@ -31,9 +31,15 @@ dependencies:
     - taxonomy.vocabulary.basic_page_types
     - taxonomy.vocabulary.event_audience
     - taxonomy.vocabulary.media_tags
+    - taxonomy.vocabulary.opportunity_sponsor
+    - taxonomy.vocabulary.opportunity_type
     - taxonomy.vocabulary.sdss_event_topics
     - taxonomy.vocabulary.sdss_focal_areas
     - taxonomy.vocabulary.sdss_organization
+    - taxonomy.vocabulary.sdss_proj_flagships
+    - taxonomy.vocabulary.sdss_proj_project_impact_pathway
+    - taxonomy.vocabulary.sdss_proj_status
+    - taxonomy.vocabulary.sdss_proj_topics
     - taxonomy.vocabulary.sdss_projects
     - taxonomy.vocabulary.sdss_research_areas
     - taxonomy.vocabulary.stanford_event_keywords
@@ -205,9 +211,15 @@ permissions:
   - 'create terms in basic_page_types'
   - 'create terms in event_audience'
   - 'create terms in media_tags'
+  - 'create terms in opportunity_sponsor'
+  - 'create terms in opportunity_type'
   - 'create terms in sdss_event_topics'
   - 'create terms in sdss_focal_areas'
   - 'create terms in sdss_organization'
+  - 'create terms in sdss_proj_flagships'
+  - 'create terms in sdss_proj_project_impact_pathway'
+  - 'create terms in sdss_proj_status'
+  - 'create terms in sdss_proj_topics'
   - 'create terms in sdss_projects'
   - 'create terms in sdss_research_areas'
   - 'create terms in stanford_event_keywords'
@@ -269,9 +281,15 @@ permissions:
   - 'delete terms in basic_page_types'
   - 'delete terms in event_audience'
   - 'delete terms in media_tags'
+  - 'delete terms in opportunity_sponsor'
+  - 'delete terms in opportunity_type'
   - 'delete terms in sdss_event_topics'
   - 'delete terms in sdss_focal_areas'
   - 'delete terms in sdss_organization'
+  - 'delete terms in sdss_proj_flagships'
+  - 'delete terms in sdss_proj_project_impact_pathway'
+  - 'delete terms in sdss_proj_status'
+  - 'delete terms in sdss_proj_topics'
   - 'delete terms in sdss_projects'
   - 'delete terms in sdss_research_areas'
   - 'delete terms in stanford_event_keywords'
@@ -332,9 +350,15 @@ permissions:
   - 'edit terms in basic_page_types'
   - 'edit terms in event_audience'
   - 'edit terms in media_tags'
+  - 'edit terms in opportunity_sponsor'
+  - 'edit terms in opportunity_type'
   - 'edit terms in sdss_event_topics'
   - 'edit terms in sdss_focal_areas'
   - 'edit terms in sdss_organization'
+  - 'edit terms in sdss_proj_flagships'
+  - 'edit terms in sdss_proj_project_impact_pathway'
+  - 'edit terms in sdss_proj_status'
+  - 'edit terms in sdss_proj_topics'
   - 'edit terms in sdss_projects'
   - 'edit terms in sdss_research_areas'
   - 'edit terms in stanford_event_keywords'

--- a/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_developer.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_developer.yml
@@ -31,9 +31,15 @@ dependencies:
     - taxonomy.vocabulary.basic_page_types
     - taxonomy.vocabulary.event_audience
     - taxonomy.vocabulary.media_tags
+    - taxonomy.vocabulary.opportunity_sponsor
+    - taxonomy.vocabulary.opportunity_type
     - taxonomy.vocabulary.sdss_event_topics
     - taxonomy.vocabulary.sdss_focal_areas
     - taxonomy.vocabulary.sdss_organization
+    - taxonomy.vocabulary.sdss_proj_flagships
+    - taxonomy.vocabulary.sdss_proj_project_impact_pathway
+    - taxonomy.vocabulary.sdss_proj_status
+    - taxonomy.vocabulary.sdss_proj_topics
     - taxonomy.vocabulary.sdss_projects
     - taxonomy.vocabulary.sdss_research_areas
     - taxonomy.vocabulary.stanford_event_keywords
@@ -243,9 +249,15 @@ permissions:
   - 'create terms in basic_page_types'
   - 'create terms in event_audience'
   - 'create terms in media_tags'
+  - 'create terms in opportunity_sponsor'
+  - 'create terms in opportunity_type'
   - 'create terms in sdss_event_topics'
   - 'create terms in sdss_focal_areas'
   - 'create terms in sdss_organization'
+  - 'create terms in sdss_proj_flagships'
+  - 'create terms in sdss_proj_project_impact_pathway'
+  - 'create terms in sdss_proj_status'
+  - 'create terms in sdss_proj_topics'
   - 'create terms in sdss_projects'
   - 'create terms in sdss_research_areas'
   - 'create terms in stanford_event_keywords'
@@ -309,9 +321,15 @@ permissions:
   - 'delete terms in basic_page_types'
   - 'delete terms in event_audience'
   - 'delete terms in media_tags'
+  - 'delete terms in opportunity_sponsor'
+  - 'delete terms in opportunity_type'
   - 'delete terms in sdss_event_topics'
   - 'delete terms in sdss_focal_areas'
   - 'delete terms in sdss_organization'
+  - 'delete terms in sdss_proj_flagships'
+  - 'delete terms in sdss_proj_project_impact_pathway'
+  - 'delete terms in sdss_proj_status'
+  - 'delete terms in sdss_proj_topics'
   - 'delete terms in sdss_projects'
   - 'delete terms in sdss_research_areas'
   - 'delete terms in stanford_event_keywords'
@@ -374,9 +392,15 @@ permissions:
   - 'edit terms in basic_page_types'
   - 'edit terms in event_audience'
   - 'edit terms in media_tags'
+  - 'edit terms in opportunity_sponsor'
+  - 'edit terms in opportunity_type'
   - 'edit terms in sdss_event_topics'
   - 'edit terms in sdss_focal_areas'
   - 'edit terms in sdss_organization'
+  - 'edit terms in sdss_proj_flagships'
+  - 'edit terms in sdss_proj_project_impact_pathway'
+  - 'edit terms in sdss_proj_status'
+  - 'edit terms in sdss_proj_topics'
   - 'edit terms in sdss_projects'
   - 'edit terms in sdss_research_areas'
   - 'edit terms in stanford_event_keywords'

--- a/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_editor.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_editor.yml
@@ -16,6 +16,7 @@ dependencies:
     - node.type.stanford_event
     - node.type.stanford_event_series
     - node.type.stanford_news
+    - node.type.stanford_opportunity
     - node.type.stanford_page
     - node.type.stanford_person
     - node.type.stanford_policy
@@ -23,9 +24,15 @@ dependencies:
     - taxonomy.vocabulary.basic_page_types
     - taxonomy.vocabulary.event_audience
     - taxonomy.vocabulary.media_tags
+    - taxonomy.vocabulary.opportunity_sponsor
+    - taxonomy.vocabulary.opportunity_type
     - taxonomy.vocabulary.sdss_event_topics
     - taxonomy.vocabulary.sdss_focal_areas
     - taxonomy.vocabulary.sdss_organization
+    - taxonomy.vocabulary.sdss_proj_flagships
+    - taxonomy.vocabulary.sdss_proj_project_impact_pathway
+    - taxonomy.vocabulary.sdss_proj_status
+    - taxonomy.vocabulary.sdss_proj_topics
     - taxonomy.vocabulary.sdss_projects
     - taxonomy.vocabulary.sdss_research_areas
     - taxonomy.vocabulary.stanford_event_keywords
@@ -114,6 +121,10 @@ permissions:
   - 'create terms in sdss_event_topics'
   - 'create terms in sdss_focal_areas'
   - 'create terms in sdss_organization'
+  - 'create terms in sdss_proj_flagships'
+  - 'create terms in sdss_proj_project_impact_pathway'
+  - 'create terms in sdss_proj_status'
+  - 'create terms in sdss_proj_topics'
   - 'create terms in sdss_projects'
   - 'create terms in sdss_research_areas'
   - 'create terms in stanford_event_keywords'
@@ -174,6 +185,10 @@ permissions:
   - 'delete terms in sdss_event_topics'
   - 'delete terms in sdss_focal_areas'
   - 'delete terms in sdss_organization'
+  - 'delete terms in sdss_proj_flagships'
+  - 'delete terms in sdss_proj_project_impact_pathway'
+  - 'delete terms in sdss_proj_status'
+  - 'delete terms in sdss_proj_topics'
   - 'delete terms in sdss_projects'
   - 'delete terms in sdss_research_areas'
   - 'delete terms in stanford_event_keywords'
@@ -231,6 +246,10 @@ permissions:
   - 'edit terms in sdss_event_topics'
   - 'edit terms in sdss_focal_areas'
   - 'edit terms in sdss_organization'
+  - 'edit terms in sdss_proj_flagships'
+  - 'edit terms in sdss_proj_project_impact_pathway'
+  - 'edit terms in sdss_proj_status'
+  - 'edit terms in sdss_proj_topics'
   - 'edit terms in sdss_projects'
   - 'edit terms in sdss_research_areas'
   - 'edit terms in stanford_event_keywords'

--- a/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_manager.yml
+++ b/docroot/profiles/sdss/sdss_profile/config/sync/user.role.site_manager.yml
@@ -17,6 +17,7 @@ dependencies:
     - node.type.stanford_event
     - node.type.stanford_event_series
     - node.type.stanford_news
+    - node.type.stanford_opportunity
     - node.type.stanford_page
     - node.type.stanford_person
     - node.type.stanford_policy
@@ -24,9 +25,15 @@ dependencies:
     - taxonomy.vocabulary.basic_page_types
     - taxonomy.vocabulary.event_audience
     - taxonomy.vocabulary.media_tags
+    - taxonomy.vocabulary.opportunity_sponsor
+    - taxonomy.vocabulary.opportunity_type
     - taxonomy.vocabulary.sdss_event_topics
     - taxonomy.vocabulary.sdss_focal_areas
     - taxonomy.vocabulary.sdss_organization
+    - taxonomy.vocabulary.sdss_proj_flagships
+    - taxonomy.vocabulary.sdss_proj_project_impact_pathway
+    - taxonomy.vocabulary.sdss_proj_status
+    - taxonomy.vocabulary.sdss_proj_topics
     - taxonomy.vocabulary.sdss_projects
     - taxonomy.vocabulary.sdss_research_areas
     - taxonomy.vocabulary.stanford_event_keywords
@@ -138,6 +145,10 @@ permissions:
   - 'create terms in sdss_event_topics'
   - 'create terms in sdss_focal_areas'
   - 'create terms in sdss_organization'
+  - 'create terms in sdss_proj_flagships'
+  - 'create terms in sdss_proj_project_impact_pathway'
+  - 'create terms in sdss_proj_status'
+  - 'create terms in sdss_proj_topics'
   - 'create terms in sdss_projects'
   - 'create terms in sdss_research_areas'
   - 'create terms in stanford_event_keywords'
@@ -206,6 +217,10 @@ permissions:
   - 'delete terms in sdss_event_topics'
   - 'delete terms in sdss_focal_areas'
   - 'delete terms in sdss_organization'
+  - 'delete terms in sdss_proj_flagships'
+  - 'delete terms in sdss_proj_project_impact_pathway'
+  - 'delete terms in sdss_proj_status'
+  - 'delete terms in sdss_proj_topics'
   - 'delete terms in sdss_projects'
   - 'delete terms in sdss_research_areas'
   - 'delete terms in stanford_event_keywords'
@@ -275,6 +290,10 @@ permissions:
   - 'edit terms in sdss_event_topics'
   - 'edit terms in sdss_focal_areas'
   - 'edit terms in sdss_organization'
+  - 'edit terms in sdss_proj_flagships'
+  - 'edit terms in sdss_proj_project_impact_pathway'
+  - 'edit terms in sdss_proj_status'
+  - 'edit terms in sdss_proj_topics'
   - 'edit terms in sdss_projects'
   - 'edit terms in sdss_research_areas'
   - 'edit terms in stanford_event_keywords'


### PR DESCRIPTION
# Summary
- This PR updates permissions for the `sdss_proj_flagships`, `sdss_proj_project_impact_pathway`, `sdss_proj_status`, and `sdss_proj_topics` taxonomies. It ensures that Site Manager, Site Editor, Site Builder, and Site Developer roles all have create, edit, and delete permissions for these vocabularies, aligning with standard taxonomy permission practices.
- Type of change: Maintenance / Permissions update

# Review By (Date)
- Please review by: 2026-03-28

# Criticality
- Criticality: 5/10
- This affects all sites using the `sdss_proj_ vocabularies`, but does not impact unrelated content or taxonomies.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch and import configuration
2. Verify via the Drupal UI (admin/people/permissions) that Site Manager, Site Editor, Site Builder, and Site Developer have create, edit, and delete permissions for the following taxonomies:
   - Project Flagships (sdss_proj_flagships)
   - Project Impact Pathway (sdss_proj_project_impact_pathway)
   - Project Status (sdss_proj_status)
   - Project Topics (sdss_proj_topics)

# Additional Context
- The taxonomy vocabularies were also renamed for clarity in the UI (e.g., "Project Flagships").
- A few Opportunity taxonomy permissions were also modified here.