### PR TITLE
Update services.yml and resolve cookie_samesite warning

### DIFF
--- a/docroot/sites/services.yml
+++ b/docroot/sites/services.yml
@@ -1,4 +1,8 @@
 parameters:
+  # Toggles the super user access policy. If your website has at least one user
+  # with the Administrator role, it is advised to set this to false. This allows
+  # you to make user 1 a regular user, strengthening the security of your site.
+  security.enable_super_user: true
   session.storage.options:
     # Default ini options for sessions.
     #
@@ -37,6 +41,13 @@ parameters:
     # @default none
     # cookie_domain: '.example.com'
     #
+    # Set the SameSite cookie attribute: 'None', 'Lax', or 'Strict'. If set,
+    # this value will override the server value. See
+    # https://www.php.net/manual/en/session.security.ini.php for more
+    # information.
+    # @default no value
+    cookie_samesite: Lax
+    #
     # Set the session ID string length. The length can be between 22 to 256. The
     # PHP recommended value is 48. See
     # https://www.php.net/manual/session.security.ini.php for more information.
@@ -53,6 +64,11 @@ parameters:
     # \Drupal\Core\Session\SessionConfiguration::__construct()
     # @default 6
     sid_bits_per_character: 6
+    # By default, Drupal generates a session cookie name based on the full
+    # domain name. Set the name_suffix to a short random string to ensure this
+    # session cookie name is unique on different installations on the same
+    # domain and path (for example, when migrating from Drupal 7).
+    name_suffix: ''
   twig.config:
     # Twig debugging:
     #
@@ -93,6 +109,21 @@ parameters:
     # Disabling the Twig cache is not recommended in production environments.
     # @default true
     cache: true
+    # File extensions:
+    #
+    # List of file extensions the Twig system is allowed to load via the
+    # twig.loader.filesystem service. Files with other extensions will not be
+    # loaded unless they are added here. For example, to allow a file named
+    # 'example.partial' to be loaded, add 'partial' to this list. To load files
+    # with no extension, add an empty string '' to the list.
+    #
+    # @default ['css', 'html', 'js', 'svg', 'twig']
+    allowed_file_extensions:
+      - css
+      - html
+      - js
+      - svg
+      - twig
   renderer.config:
     # Renderer required cache contexts:
     #
@@ -132,6 +163,14 @@ parameters:
       #
       # @default []
       tags: []
+    # Renderer cache debug:
+    #
+    # Allows cache debugging output for each rendered element.
+    #
+    # Enabling render cache debugging is not recommended in production
+    # environments.
+    # @default false
+    debug: false
   # Cacheability debugging:
   #
   # Responses with cacheability metadata (CacheableResponseInterface instances)
@@ -146,15 +185,15 @@ parameters:
   # @default false
   http.response.debug_cacheability_headers: false
   factory.keyvalue: {}
-    # Default key/value storage service to use.
-    # @default keyvalue.database
-    # default: keyvalue.database
-    # Collection-specific overrides.
-    # state: keyvalue.database
+  # Default key/value storage service to use.
+  # @default keyvalue.database
+  # default: keyvalue.database
+  # Collection-specific overrides.
+  # state: keyvalue.database
   factory.keyvalue.expirable: {}
-    # Default key/value expirable storage service to use.
-    # @default keyvalue.database.expirable
-    # default: keyvalue.database.expirable
+  # Default key/value expirable storage service to use.
+  # @default keyvalue.database.expirable
+  # default: keyvalue.database.expirable
   # Allowed protocols for URL generation.
   filter_protocols:
     - http
@@ -181,11 +220,20 @@ parameters:
     allowedHeaders: []
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: []
-    # Configure requests allowed from specific origins.
+    # Configure requests allowed from specific origins. Do not include trailing
+    # slashes with URLs.
     allowedOrigins: ['*']
+    # Configure requests allowed from origins, matching against regex patterns.
+    allowedOriginsPatterns: []
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.
     maxAge: false
     # Sets the Access-Control-Allow-Credentials header.
     supportsCredentials: false
+
+  queue.config:
+    # The maximum number of seconds to wait if a queue is temporarily suspended.
+    # This is not applicable when a queue is suspended but does not specify
+    # how long to wait before attempting to resume.
+    suspendMaximumWait: 30


### PR DESCRIPTION
# Summary
The original PR #769 pulled the `services.yml` from the wrong `default.services.yml` which was outdated. This pulls in the correct configuration, and also addresses the `cookie_samesite` warning. The warning appear on the page was also breaking a functional test, which is resolved with this change as well.
