### PR TITLE
Require davidrjonas/composer-lock-diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "citation-style-language/styles-distribution": "1.0.0",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6",
+        "davidrjonas/composer-lock-diff": "^1.0",
         "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.1",
         "drupal/address": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a23ab957bcced35bc41b60501acd5e7",
+    "content-hash": "0bf23516ec67a9c80e3ff185d2467571",
     "packages": [
         {
             "name": "acquia/blt",
@@ -28169,5 +28169,5 @@
         "ext-imagick": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
# Summary
This is an attempt to get ahead of an issue caused by the migration to SWS Drush Commands and removal of BLT. By deliberatly requiring `davidrjonas/composer-lock-diff` now we'll avoid this issue.

See: https://github.com/SU-HSDO/suhumsci/pull/2182

> The composer-lock-diff is used in developer and automated workflows. The move to SWS Drush Commands removed the `su-sws/blt-sws` package, which is how `davidrjonas/composer-lock-diff` was being required. It now needs to be re-added manually.
