### PR TITLE
SDSS-1607: Remove default home page banner superhead value

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/content/node/72f0069b-f1ec-4122-af73-6aa841faea90.yml
+++ b/docroot/profiles/sdss/sdss_profile/content/node/72f0069b-f1ec-4122-af73-6aa841faea90.yml
@@ -90,9 +90,6 @@ default:
           su_banner_image:
             -
               entity: 6fac3713-f499-4750-a7bc-32c16a59043a
-          su_banner_sup_header:
-            -
-              value: 'Stanford University'
   su_page_components:
     -
       entity:

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -225,3 +225,22 @@ function sdss_profile_update_10021(&$sandbox) {
     '@updated' => $sandbox['updated'],
   ]);
 }
+
+/**
+ * Clears the su_banner_sup_header field for the banner paragraph with a specific UUID.
+ */
+function sdss_profile_update_10022() {
+  // The Paragraph UUID for the banner.
+  $paragraph_uuid = '79c98714-281a-450d-b574-2971426b1f3e';
+
+  // Load the paragraph by UUID.
+  $storage = \Drupal::entityTypeManager()->getStorage('paragraph');
+  $paragraphs = $storage->loadByProperties(['uuid' => $paragraph_uuid]);
+  $paragraph = reset($paragraphs);
+
+  if ($paragraph && $paragraph->hasField('su_banner_sup_header')) {
+    $paragraph->set('su_banner_sup_header', NULL);
+    $paragraph->save();
+    \Drupal::logger('sdss_profile')->notice('Cleared su_banner_sup_header for banner paragraph with UUID @uuid.', ['@uuid' => $paragraph_uuid]);
+  }
+}

--- a/docroot/profiles/sdss/sdss_profile/sdss_profile.install
+++ b/docroot/profiles/sdss/sdss_profile/sdss_profile.install
@@ -227,7 +227,7 @@ function sdss_profile_update_10021(&$sandbox) {
 }
 
 /**
- * Clears the su_banner_sup_header field for the banner paragraph with a specific UUID.
+ * Clear superhead value for default home page banner paragraph.
  */
 function sdss_profile_update_10022() {
   // The Paragraph UUID for the banner.


### PR DESCRIPTION
# Summary
- Removes the default value for the banner superhead ("Stanford University") from the home page default content YAML and clears the value from all existing sites. This prevents the hidden superhead field from displaying in banner previews on the home page edit form.
- Type: Bug fix / Maintenance

# Criticality
- 3/10. This only affects the home page banner preview experience and does not impact live site content or end users. It improves editorial clarity.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch: `git checkout SDSS-1607--drop-default-superheader-banner`
2. Run `composer install` if needed
3. Run database updates: `drush updb -y`
4. Edit the home page and verify the banner preview no longer shows "Stanford University" in the superhead area
5. Confirm no regressions on other banners or hero components

# Related Issues/PR's
[SDSS-1607](https://stanfordits.atlassian.net/browse/SDSS-1607): Unknown field displaying in banner

# Additional Context
- The superhead field was set in default content but hidden from display/edit forms, causing confusion in previews. This PR removes the value and adds an update hook to clear it from existing sites. Field deprecation will be handled in a future ticket.


[SDSS-1607]: https://stanfordits.atlassian.net/browse/SDSS-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ