### PR TITLE
Departments Slider Paragraph | Fix department slider class specificity bug

### DIFF
--- a/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/js/components/gsap-functions.js
+++ b/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/js/components/gsap-functions.js
@@ -18,7 +18,7 @@ window.addEventListener('load', function () {
         wrapper = document.createElement('div');
         wrapper.id = "paragraph-pin-wrapper";
 
-        document.querySelector('.stanford-page').insertBefore(wrapper, sliderParent);
+        document.querySelector('.stanford-page.su-page-components').insertBefore(wrapper, sliderParent);
 
         wrapper.appendChild(sliderParent);
 


### PR DESCRIPTION
# Summary
This updates line 21 of '/docroot/profiles/sdss/sdss_profile/themes/sdss_subtheme/js/components/gsap-functions.js' to fix a bug where the Departments Slider paragraph was failing when there was more than one ".stanford-page" wrapper on the page.

# Review By (Date)
If possible (not sure if we're in a code freeze) before the next deploy.

# Criticality
1-2
