### PR TITLE
SDSS-1638: Update GitHub Actions to support Node.js 24 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/acquia_cleanup.yml
+++ b/.github/workflows/acquia_cleanup.yml
@@ -18,9 +18,9 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/copy_dbs_to_staging.yml
+++ b/.github/workflows/copy_dbs_to_staging.yml
@@ -17,9 +17,9 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/dependency_updates.yml
+++ b/.github/workflows/dependency_updates.yml
@@ -34,7 +34,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set git safe directory
@@ -43,7 +43,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -18,11 +18,11 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || '' }}
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,7 +14,7 @@ jobs:
   pr-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,9 +9,9 @@ jobs:
     container:
       image: pookmish/drupal8ci:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,13 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.tag.outputs.tag }}
         with:
           ref: ${{ github.sha }}
       - name: Restore Cache
         if: ${{ steps.tag.outputs.tag }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/site-sync-test.yml
+++ b/.github/workflows/site-sync-test.yml
@@ -34,9 +34,9 @@ jobs:
           name: id_rsa
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
           if_key_exists: fail
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,9 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -45,7 +45,7 @@ jobs:
           composer install -n &&
           blt tests:phpunit:coverage --no-interaction
       - name: Save Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-tests-results
@@ -80,9 +80,9 @@ jobs:
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Restore Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -107,7 +107,7 @@ jobs:
       - name: Run tests
         run: blt codeception --suite=${{ matrix.suite }}
       - name: Save Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: newsite-${{ matrix.suite }}-tests


### PR DESCRIPTION
# Summary
- TL;DR: Update GitHub Actions workflow action versions to remove Node.js 20 deprecation warnings and ensure compatibility with Node.js 24 by upgrading `actions/checkout`, `actions/cache`, and `actions/upload-artifact` where used.
- Change type: Maintenance (CI/workflow update).

# Review By (Date)
- 2026-06-02 (opt into Node.js 24 before it becomes the default)

# Criticality
- 5 — Affects CI workflows across the repository; not a functional site change but impacts CI reliability and future runner compatibility.

# Review Tasks
## Setup tasks and/or behavior to test
1. Check out this branch locally:
   - `git fetch && git checkout SDSS-1638--update-github-actions-versions`
2. Inspect modified workflow files under `.github/workflows/` to confirm expected version updates.
3. Push the branch and open the PR (or use the existing PR) so Actions run on GitHub.
4. Verify representative workflows run without the Node.js 20 deprecation warning (e.g., `tests.yml`, `phpcs.yml`).
5. Confirm caching still restores and saves as expected and that artifacts upload without errors.

# Related Issues/PR's
[SDSS-1638](https://stanfordits.atlassian.net/browse/SDSS-1638): Update GitHub Actions to support Node.js 24 (Node 20 deprecation)

[SDSS-1638]: https://stanfordits.atlassian.net/browse/SDSS-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ